### PR TITLE
Drag a Markdown/text file onto Peck or Hatch to add it as a source

### DIFF
--- a/src/electron/electron/handler.cljs
+++ b/src/electron/electron/handler.cljs
@@ -548,6 +548,9 @@
 (defmethod handle :wikiIngestMetrics [_ [_ vault-root]]
   (wiki/hatch-metrics! vault-root))
 
+(defmethod handle :wikiAddEgg [_ [_ vault-root filename content]]
+  (wiki/add-egg! vault-root filename content))
+
 (defmethod handle :wikiChat [_ [_ vault-root question trace?]]
   (wiki/peck! vault-root question (boolean trace?)))
 

--- a/src/electron/electron/wiki.cljs
+++ b/src/electron/electron/wiki.cljs
@@ -179,6 +179,61 @@
        (resolve* (js/JSON.parse (fs/readFileSync (roost-file vault-root "hatch-metrics.json") "utf8")))
        (catch :default _ (resolve* nil))))))
 
+(def ^:private egg-extensions
+  "Text formats Hatch can read — a source dropped onto the app must be one of
+  these. PDF/Word would need an extraction step the retrieval layer doesn't
+  have yet."
+  #{".md" ".markdown" ".mdown" ".txt" ".text" ".org"})
+
+(defn- unique-egg-path
+  "eggs/<filename>, or eggs/<stem> (2)<ext>, (3)<ext>… when the name is taken."
+  [eggs-dir filename]
+  (let [ext  (.extname node-path filename)
+        stem (subs filename 0 (- (count filename) (count ext)))]
+    (loop [n 1]
+      (let [nm   (if (= n 1) filename (str stem " (" n ")" ext))
+            full (.join node-path eggs-dir nm)]
+        (if (fs/existsSync full) (recur (inc n)) [nm full])))))
+
+(defn add-egg!
+  "Write `content` (a dropped file's text) into <graph>/eggs/ under `filename`,
+  so it becomes a Hatch source. Resolves:
+    {:ok true  :name <name>}                     — written
+    {:ok true  :name <name> :duplicate <name>}   — identical text already in eggs/
+    {:ok false :reason \"no-graph\"}
+    {:ok false :reason \"unsupported\" :ext <ext>}
+    {:ok false :reason <message>}"
+  [vault-root filename content]
+  (p/create
+   (fn [resolve* _reject]
+     (try
+       (let [ext (when (string? filename)
+                   (string/lower-case (.extname node-path filename)))]
+         (cond
+           (or (string/blank? vault-root) (string/blank? filename))
+           (resolve* #js {:ok false :reason "no-graph"})
+
+           (not (contains? egg-extensions ext))
+           (resolve* #js {:ok false :reason "unsupported" :ext (or ext "")})
+
+           :else
+           (let [eggs-dir (.join node-path vault-root "eggs")
+                 _ (fs/mkdirSync eggs-dir #js {:recursive true})
+                 dup (->> (fs/readdirSync eggs-dir)
+                          (filter (fn [nm]
+                                    (let [p (.join node-path eggs-dir nm)]
+                                      (and (try (.isFile (fs/statSync p)) (catch :default _ false))
+                                           (= content (fs/readFileSync p "utf8"))))))
+                          first)]
+             (if dup
+               (resolve* #js {:ok true :name dup :duplicate dup})
+               (let [[nm full] (unique-egg-path eggs-dir (.basename node-path filename))]
+                 (fs/writeFileSync full content "utf8")
+                 (resolve* #js {:ok true :name nm}))))))
+       (catch :default e
+         (log-error (str "add-egg! " filename ": " (.-message e)))
+         (resolve* #js {:ok false :reason (.-message e)}))))))
+
 (defn peck!
   "Runs the Peck workflow for `question` without filing the answer back.
   Resolves to {:answer :citedSlugs :candidateSlugs :steps}. `steps` is what

--- a/src/main/frontend/components/chat.cljs
+++ b/src/main/frontend/components/chat.cljs
@@ -19,6 +19,7 @@
             [clojure.string :as string]
             [electron.ipc :as ipc]
             [frontend.components.block :as block]
+            [frontend.components.drop-source :as drop-source]
             [frontend.components.llm-banner :as llm-banner]
             [frontend.components.telemetry :as telemetry]
             [frontend.config :as config]
@@ -202,4 +203,6 @@
    {:style {:display "flex" :flex-direction "column"
             :flex "1 1 auto" :min-height 0
             :width "100%" :max-width "46rem" :margin "0 auto" :padding "0 .5rem"}}
-   (chat-panel)])
+   (drop-source/drop-zone
+    {:style {:display "flex" :flex-direction "column" :flex "1 1 auto" :min-height 0}}
+    (chat-panel))])

--- a/src/main/frontend/components/drop_source.cljs
+++ b/src/main/frontend/components/drop_source.cljs
@@ -1,0 +1,108 @@
+(ns frontend.components.drop-source
+  "Drag a Markdown / text file onto the Peck view or the Hatch panel and it
+  lands in <graph>/eggs/ as a Hatch source — no need to leave the app and use
+  the OS file manager. `drop-zone` wraps its children: an overlay shows while a
+  file is dragged over, a notification reports the result on drop. PDF/Word are
+  rejected with a note (the retrieval layer can't read them yet)."
+  (:require [cljs-bean.core :as bean]
+            [clojure.string :as string]
+            [electron.ipc :as ipc]
+            [frontend.config :as config]
+            [frontend.handler.notification :as notification]
+            [frontend.state :as state]
+            [promesa.core :as p]
+            [rum.core :as rum]))
+
+(def ^:private accepted-exts #{"md" "markdown" "mdown" "txt" "text" "org"})
+
+(defn- vault-root [] (config/get-repo-dir (state/get-current-repo)))
+
+(defn- ext-of [filename]
+  (let [i (string/last-index-of (or filename "") ".")]
+    (when (and i (pos? i))
+      (string/lower-case (subs filename (inc i))))))
+
+(defn- has-files? [^js e]
+  (some-> e .-dataTransfer .-types (.includes "Files")))
+
+(defn- files-seq [^js e]
+  (some-> e .-dataTransfer .-files js/Array.from seq))
+
+(defn- notify-added! [name]
+  (notification/show!
+   [:div.text-sm
+    [:div "Added " [:b name] " to " [:code "eggs/"] "."]
+    [:button.text-xs.underline.opacity-80.hover:opacity-100.mt-1
+     {:on-click (fn []
+                  (notification/clear-all!)
+                  (state/pub-event! [:modal/show-hatch]))}
+     "Hatch it now →"]]
+   :success false))
+
+(defn- add-one! [^js file on-added]
+  (let [name (.-name file)
+        ext  (ext-of name)]
+    (if-not (contains? accepted-exts ext)
+      (notification/show!
+       [:div.text-sm
+        "Can't add " [:b name] " — Kip reads Markdown and text files ("
+        [:code ".md"] ", " [:code ".txt"] ", " [:code ".org"] "). "
+        "PDF and Word support is on the way."]
+       :warning true)
+      (-> (.text file)
+          (p/then #(ipc/ipc "wikiAddEgg" (vault-root) name %))
+          (p/then (fn [r]
+                    (let [{:keys [ok name duplicate reason]} (bean/->clj r)]
+                      (cond
+                        (and ok duplicate)
+                        (notification/show! (str name " is already in your coop.") :info true)
+
+                        ok
+                        (do (notify-added! name)
+                            (when on-added (on-added name)))
+
+                        (= reason "no-graph")
+                        (notification/show! "Open a graph first, then drop your file." :warning true)
+
+                        :else
+                        (notification/show! (str "Couldn't add " name ": " reason) :error true)))))
+          (p/catch (fn [err]
+                     (notification/show! (str "Couldn't read " name ": " err) :error true)))))))
+
+(defn- handle-drop! [^js e on-added]
+  (.preventDefault e)
+  (doseq [file (files-seq e)]
+    (add-one! file on-added)))
+
+(rum/defcs drop-zone
+  "Wrap content in a file-drop target. opts: {:on-added (fn [name]) :class
+  <string> :style <map>}. The wrapper is `position: relative` so the
+  drag-over overlay can fill it; pass :style to control how it sizes in its
+  parent."
+  < (rum/local false ::over?)
+  [state opts & children]
+  (let [*over? (::over? state)
+        {:keys [on-added class style]} opts]
+    [:div.relative
+     {:class class
+      :style style
+      :on-drag-over (fn [e]
+                      (when (has-files? e)
+                        (.preventDefault e)
+                        (reset! *over? true)))
+      :on-drag-leave (fn [^js e]
+                       (let [ct (.-currentTarget e)
+                             rt (.-relatedTarget e)]
+                         (when (or (nil? rt) (not (.contains ct rt)))
+                           (reset! *over? false))))
+      :on-drop (fn [e]
+                 (reset! *over? false)
+                 (handle-drop! e on-added))}
+     (into [:<>] children)
+     (when @*over?
+       [:div.absolute.inset-0.z-20.flex.items-center.justify-center.pointer-events-none
+        {:class "bg-gray-01"
+         :style {:opacity 0.92}}
+        [:div.border-2.border-dashed.rounded-lg.px-6.py-4.text-sm.font-medium.opacity-90
+         {:style {:border-color "var(--ls-active-primary-color, #10b981)"}}
+         "Drop to add to your coop"]])]))

--- a/src/main/frontend/components/ingest.cljs
+++ b/src/main/frontend/components/ingest.cljs
@@ -13,6 +13,7 @@
   (:require [cljs-bean.core :as bean]
             [clojure.string :as string]
             [electron.ipc :as ipc]
+            [frontend.components.drop-source :as drop-source]
             [frontend.components.llm-banner :as llm-banner]
             [frontend.components.telemetry :as telemetry]
             [frontend.config :as config]
@@ -126,8 +127,10 @@
         remaining  @*remaining
         started?   (or (seq (:hatched done)) (seq (:failed done)) (some? remaining))
         pending-n  (if started? (or remaining 0) (count (:pending preview)))]
-    [:div.w-full.mx-auto {:class "md:max-w-[600px]"}
-     [:h2#modal-headline.text-xl.mb-3 "Hatch sources"]
+    (drop-source/drop-zone
+     {:on-added (fn [_] (load-preview! *preview *error *busy?))}
+     [:div.w-full.mx-auto {:class "md:max-w-[600px]"}
+      [:h2#modal-headline.text-xl.mb-3 "Hatch sources"]
      [:p.text-sm.opacity-70.mb-3
       "Turns new or changed files in " [:code "eggs/"] ", " [:code "journals/"] " and "
       [:code "pages/"] " into nest pages — no per-file review. Runs in batches of "
@@ -208,7 +211,7 @@
 
         (when (seq (:empty preview))
           [:div.text-xs.opacity-50.mt-2
-           (str (count (:empty preview)) " near-empty file(s) skipped.")])])]))
+           (str (count (:empty preview)) " near-empty file(s) skipped.")])])])))
 
 (defn show-hatch-modal! [e]
   (state/set-modal! hatch-modal)

--- a/src/main/frontend/handler/events.cljs
+++ b/src/main/frontend/handler/events.cljs
@@ -20,6 +20,7 @@
             [frontend.components.encryption :as encryption]
             [frontend.components.file-sync :as file-sync]
             [frontend.components.git :as git-component]
+            [frontend.components.ingest :as ingest]
             [frontend.components.plugins :as plugin]
             [frontend.components.shell :as shell]
             [frontend.components.whiteboard :as whiteboard]
@@ -332,6 +333,9 @@
 (defmethod handle :modal/show-cards [_]
   (state/set-modal! srs/global-cards {:id :srs
                                       :label "flashcards__cp"}))
+
+(defmethod handle :modal/show-hatch [_]
+  (state/set-modal! ingest/hatch-modal))
 
 (defmethod handle :modal/show-instruction [_]
   (state/set-modal! capacitor-fs/instruction {:id :instruction


### PR DESCRIPTION
Closes #2.

### Problem
The only way to add a Hatch source was to leave the app, open the OS file manager, and copy a file into `<graph>/eggs/`. The getting-started guide says exactly that.

### Change
Drop a `.md` / `.markdown` / `.txt` / `.org` file onto **the Peck view** or **the open Hatch panel**:

- a *"Drop to add to your coop"* overlay shows while dragging
- on drop the file is copied into `<graph>/eggs/` and a notification reports it:
  **"Added `X` to eggs/"** with a **"Hatch it now →"** link (opens the Hatch modal)
- a byte-identical file already in `eggs/` is detected and reported, not re-added
- a name collision auto-suffixes: `note (2).md`
- a PDF / Word / other file is rejected with a note that Kip can't read it yet

### Files
- `electron.wiki/add-egg!` + `:wikiAddEgg` IPC — the copy/dedup/reject logic
- **new** `frontend.components.drop-source/drop-zone` — the wrapper (overlay + notification)
- `chat.cljs` wraps the Peck view; `ingest.cljs` wraps the Hatch modal body (a drop there also reloads the pending-files preview)
- `:modal/show-hatch` event in `events.cljs`

### Not clashing with the editor's file drop
The existing whole-window asset drop (`container.cljs`) only acts while a block is being edited — never in Peck mode — so the two don't collide.

### Testing
Verified end-to-end in the dev app via the cljs REPL (synthetic drag/drop events with a real `File`):
- drag-over overlay appears / clears
- `.md` drop → file lands in `eggs/`, "Added…" notification, "Hatch it now" opens the modal with the new file pending
- `.xlsx` drop → "Kip reads Markdown and text files…" warning, nothing written
- `add-egg!` unit-checked over every branch: new / byte-identical duplicate / name collision / unsupported ext / no graph open

(The `add-egg!` logic is electron-side cljs; there's no electron test runner in this repo, hence the REPL verification.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)