### PR TITLE
Peck empty state: a first-run checklist until Kip is set up

### DIFF
--- a/src/electron/electron/handler.cljs
+++ b/src/electron/electron/handler.cljs
@@ -551,6 +551,9 @@
 (defmethod handle :wikiAddEgg [_ [_ vault-root filename content]]
   (wiki/add-egg! vault-root filename content))
 
+(defmethod handle :wikiCoopCounts [_ [_ vault-root]]
+  (wiki/coop-counts! vault-root))
+
 (defmethod handle :wikiChat [_ [_ vault-root question trace?]]
   (wiki/peck! vault-root question (boolean trace?)))
 

--- a/src/electron/electron/wiki.cljs
+++ b/src/electron/electron/wiki.cljs
@@ -234,6 +234,31 @@
          (log-error (str "add-egg! " filename ": " (.-message e)))
          (resolve* #js {:ok false :reason (.-message e)}))))))
 
+(defn- count-files
+  "Count of files under `dir` (recursively) matching `pred` (a fn of the
+  relative path). 0 when the folder doesn't exist."
+  [dir pred]
+  (try
+    (->> (fs/readdirSync dir #js {:recursive true})
+         (filter pred)
+         count)
+    (catch :default _ 0)))
+
+(defn coop-counts!
+  "Cheap fs read for the first-run checklist: how many source files sit in
+  eggs/ and how many pages exist under nest/ (index.md, which is generated,
+  doesn't count). Both 0 before the folders are created. No subprocess."
+  [vault-root]
+  (p/create
+   (fn [resolve* _reject]
+     (if (string/blank? vault-root)
+       (resolve* #js {:eggs 0 :nestPages 0})
+       (resolve* #js {:eggs      (count-files (.join node-path vault-root "eggs")
+                                              #(contains? egg-extensions (string/lower-case (.extname node-path %))))
+                      :nestPages (count-files (.join node-path vault-root "nest")
+                                              #(and (= ".md" (string/lower-case (.extname node-path %)))
+                                                    (not= "index.md" (.basename node-path %))))})))))
+
 (defn peck!
   "Runs the Peck workflow for `question` without filing the answer back.
   Resolves to {:answer :citedSlugs :candidateSlugs :steps}. `steps` is what

--- a/src/main/frontend/components/chat.cljs
+++ b/src/main/frontend/components/chat.cljs
@@ -20,6 +20,7 @@
             [electron.ipc :as ipc]
             [frontend.components.block :as block]
             [frontend.components.drop-source :as drop-source]
+            [frontend.components.first-run :as first-run]
             [frontend.components.llm-banner :as llm-banner]
             [frontend.components.telemetry :as telemetry]
             [frontend.config :as config]
@@ -135,23 +136,48 @@
       (when (seq steps) (steps-line steps))
       [:div.prose.prose-sm.max-w-none (block/inline-text {} :markdown text)]])])
 
-(rum/defc empty-state
-  []
-  [:div.flex.flex-col.items-center.text-center.opacity-80.py-8.select-none
-   [:pre.font-mono.text-sm.mb-3
-    {:aria-hidden "true"
-     :style {:color "var(--ls-active-primary-color, #10b981)" :margin 0 :line-height 1.3}}
-    "  \\\\\n  (o>\n\\_//)\n \\_/_)\n  _|_"]
-   [:div.text-sm.font-medium "Kip"]
-   [:div.text-sm.opacity-70.mt-1.mb-4 {:style {:max-width "28rem"}}
-    "Ask your nest a question, or tell it something to remember."]
-   [:div.flex.flex-col.gap-1.5.items-center
-    (for [p example-prompts]
-      [:button.text-xs.px-3.py-1.rounded-full.transition-colors
-       {:key p
-        :class "bg-gray-03 hover:bg-gray-04 opacity-80 hover:opacity-100"
-        :on-click #(reset! *input p)}
-       p])]])
+(defn- first-run-showing? [llm counts]
+  (and (not (first-run/dismissed?))
+       (not (first-run/ready? llm counts (first-run/steps llm counts)))))
+
+(rum/defcs empty-state
+  < rum/reactive
+  (rum/local nil ::poll)
+  {:did-mount    (fn [state]
+                   (first-run/refresh!)
+                   (reset! (::poll state) (js/setInterval first-run/refresh! 3000))
+                   state)
+   :did-update   (fn [state]
+                   (let [llm (:kip/llm @state/state)
+                         counts (:kip/coop-counts @state/state)]
+                     (when (and (not (first-run/dismissed?))
+                                (first-run/ready? llm counts (first-run/steps llm counts)))
+                       (first-run/mark-dismissed!)))
+                   state)
+   :will-unmount (fn [state]
+                   (when-let [id @(::poll state)] (js/clearInterval id))
+                   state)}
+  [_state]
+  (let [llm (state/sub :kip/llm)
+        counts (state/sub :kip/coop-counts)]
+    [:div.flex.flex-col.items-center.text-center.opacity-80.py-8.select-none
+     [:pre.font-mono.text-sm.mb-3
+      {:aria-hidden "true"
+       :style {:color "var(--ls-active-primary-color, #10b981)" :margin 0 :line-height 1.3}}
+      "  \\\\\n  (o>\n\\_//)\n \\_/_)\n  _|_"]
+     [:div.text-sm.font-medium "Kip"]
+     (if (first-run-showing? llm counts)
+       [:div.mt-3 (first-run/checklist (first-run/steps llm counts))]
+       [:<>
+        [:div.text-sm.opacity-70.mt-1.mb-4 {:style {:max-width "28rem"}}
+         "Ask your nest a question, or tell it something to remember."]
+        [:div.flex.flex-col.gap-1.5.items-center
+         (for [p example-prompts]
+           [:button.text-xs.px-3.py-1.rounded-full.transition-colors
+            {:key p
+             :class "bg-gray-03 hover:bg-gray-04 opacity-80 hover:opacity-100"
+             :on-click #(reset! *input p)}
+            p])]])]))
 
 (rum/defcs chat-panel
   < rum/reactive

--- a/src/main/frontend/components/drop_source.cljs
+++ b/src/main/frontend/components/drop_source.cljs
@@ -8,6 +8,7 @@
             [clojure.string :as string]
             [electron.ipc :as ipc]
             [frontend.config :as config]
+            [frontend.handler.coop :as coop]
             [frontend.handler.notification :as notification]
             [frontend.state :as state]
             [promesa.core :as p]
@@ -59,6 +60,7 @@
 
                         ok
                         (do (notify-added! name)
+                            (coop/refresh-counts!)
                             (when on-added (on-added name)))
 
                         (= reason "no-graph")

--- a/src/main/frontend/components/first_run.cljs
+++ b/src/main/frontend/components/first_run.cljs
@@ -1,0 +1,60 @@
+(ns frontend.components.first-run
+  "The first-run checklist shown in Peck's empty state until Kip is ready to be
+  useful: set an LLM provider, add a source, hatch it. Each step ticks off on
+  its own; once all three are done (or the user has done them once — a flag is
+  kept per graph) the empty state shows the normal example prompts instead."
+  (:require [frontend.handler.coop :as coop]
+            [frontend.handler.llm :as llm-handler]
+            [frontend.state :as state]
+            [frontend.storage :as storage]
+            [rum.core :as rum]))
+
+(defn- done-key []
+  (str "kip-first-run-done-" (state/get-current-repo)))
+
+(defn dismissed? []
+  (boolean (storage/get (done-key))))
+
+(defn mark-dismissed! []
+  (storage/set (done-key) true))
+
+(defn refresh! []
+  (llm-handler/refresh!)
+  (coop/refresh-counts!))
+
+(defn steps
+  "The three checklist steps, from the cached :kip/llm and :kip/coop-counts."
+  [llm counts]
+  [{:label "Set an LLM provider"
+    :done? (boolean (:configured? llm))
+    :on-click #(state/open-settings! :llm)}
+   {:label "Add a source"
+    :done? (pos? (:eggs counts 0))
+    :note "drop a Markdown or text file anywhere on this panel"}
+   {:label "Hatch it into The Nest"
+    :done? (pos? (:nestPages counts 0))
+    :on-click #(state/pub-event! [:modal/show-hatch])}])
+
+(defn ready?
+  "True once we've read both bits of state and every step is done — the point
+  at which the checklist gives way to the example prompts."
+  [llm counts steps]
+  (and (:loaded? llm) (:loaded? counts) (every? :done? steps)))
+
+(rum/defc checklist
+  "The rendered checklist. `steps` from `steps`."
+  [step-list]
+  [:div.flex.flex-col.gap-2.items-start.text-left.mx-auto
+   {:style {:max-width "20rem"}}
+   [:div.text-xs.font-medium.opacity-60.mb-1 "To get started"]
+   (for [{:keys [label done? note on-click]} step-list]
+     [:div.flex.items-start.gap-2.text-sm
+      {:key label :class (when done? "opacity-50")}
+      [:span.mt-px {:style {:color (when done? "var(--ls-active-primary-color, #10b981)")}}
+       (if done? "✓" "○")]
+      [:div
+       (if (and on-click (not done?))
+         [:button.underline.hover:opacity-100.opacity-90 {:on-click on-click} label]
+         [:span label])
+       (when (and note (not done?))
+         [:div.text-xs.opacity-60 note])]])])

--- a/src/main/frontend/components/ingest.cljs
+++ b/src/main/frontend/components/ingest.cljs
@@ -17,6 +17,7 @@
             [frontend.components.llm-banner :as llm-banner]
             [frontend.components.telemetry :as telemetry]
             [frontend.config :as config]
+            [frontend.handler.coop :as coop]
             [frontend.handler.llm :as llm-handler]
             [frontend.state :as state]
             [frontend.util :as util]
@@ -60,7 +61,8 @@
                   (swap! *done (fn [d] {:hatched (into (:hatched d) hatched)
                                         :failed  (into (:failed d) failed)}))
                   (reset! *remaining remaining)
-                  (reset! *metrics metrics))))
+                  (reset! *metrics metrics)
+                  (coop/refresh-counts!))))
       (p/catch (fn [e] (reset! *error (str e))))
       (p/finally (fn []
                    (stop-poll! *progress *poll-id)

--- a/src/main/frontend/handler/coop.cljs
+++ b/src/main/frontend/handler/coop.cljs
@@ -1,0 +1,22 @@
+(ns frontend.handler.coop
+  "Small reads of the open coop for the first-run checklist — how many source
+  files are in eggs/ and how many pages exist under nest/. Cached in the app
+  db under :kip/coop-counts so the Peck empty state can show what's left to do
+  before Kip is useful."
+  (:require [cljs-bean.core :as bean]
+            [electron.ipc :as ipc]
+            [frontend.config :as config]
+            [frontend.state :as state]
+            [promesa.core :as p]))
+
+(defn- vault-root []
+  (config/get-repo-dir (state/get-current-repo)))
+
+(defn refresh-counts!
+  "Re-read eggs/ and nest/ counts into :kip/coop-counts. Never throws."
+  []
+  (-> (ipc/ipc "wikiCoopCounts" (vault-root))
+      (p/then (fn [r]
+                (state/set-state! :kip/coop-counts
+                                  (assoc (bean/->clj r) :loaded? true))))
+      (p/catch (fn [_] nil))))

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -123,6 +123,10 @@
      ;; save). :loaded? false until the first read resolves.
      :kip/llm                               {:loaded? false :configured? false}
 
+     ;; Cached eggs/ + nest/ counts for the Peck first-run checklist —
+     ;; frontend.handler.coop/refresh-counts!.
+     :kip/coop-counts                       {:loaded? false :eggs 0 :nestPages 0}
+
      :config                                {}
      :block/component-editing-mode?         false
      :editor/op                             nil


### PR DESCRIPTION
Closes #3.

### Problem
A new user opened straight into Peck with three example prompts and no signal that an LLM provider had to be configured, a file dropped in, and a hatch run before any of those prompts would work.

### Change
Peck's empty state now shows a **3-step checklist** while Kip isn't ready:

| | step | action |
|---|---|---|
| ○ | Set an LLM provider | opens Settings → LLM |
| ○ | Add a source | drop a Markdown/text file on the panel (#2) |
| ○ | Hatch it into The Nest | opens the Hatch modal |

Each step ticks off on its own (green ✓, dimmed). When all three are done the normal example prompts come back, and a `localStorage` flag per graph keeps them back so the checklist doesn't reappear later.

### Files
- `electron.wiki/coop-counts!` + `:wikiCoopCounts` — recursive count of `eggs/` sources and `nest/` pages (the generated `nest/index.md` is excluded)
- **new** `frontend.handler.coop` — caches counts under `:kip/coop-counts`
- **new** `frontend.components.first-run` — the steps + rendered checklist
- `chat.cljs` `empty-state` — now reactive; polls every 3s while shown; swaps checklist ↔ prompts on `ready?`; persists dismissal in `:did-update`
- `drop-source` / the Hatch run refresh the counts so a step ticks immediately

### Testing
- `coop-counts!` verified via the electron REPL: real graph → `{eggs 1, nestPages 0}`; `nil` graph → zeros; recursive nest count with `index.md` excluded
- In the dev app: checklist renders with the right ticks (provider done, source done, hatch pending), "Hatch it into The Nest" opens the modal, adding a `nest/` page flips the empty state to the example prompts, and the dismissal flag is written

### Stacking
Builds on #1 (`frontend.handler.llm`) and #2 (`drop-source`, the `eggs/` copy), both now merged — so this targets `version/file` cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)