### PR TITLE
i18n: :help/about says "Kip", not "Logseq"

### DIFF
--- a/src/resources/dicts/af.edn
+++ b/src/resources/dicts/af.edn
@@ -1,4 +1,4 @@
-{:help/about "Oor Logseq"
+{:help/about "Oor Kip"
  :help/bug "Fout verslag"
  :help/feature "Funksie versoek"
  :help/changelog "Verandering-dagboek"

--- a/src/resources/dicts/ca.edn
+++ b/src/resources/dicts/ca.edn
@@ -373,7 +373,7 @@
  :header/more                                       "Mes"
  :header/search                                     "Cercar"
  :header/toggle-left-sidebar                        "Alternar panell lateral esquerre"
- :help/about                                        "Sobre Logseq"
+ :help/about                                        "Sobre Kip"
  :help/awesome-logseq                               "Increïble Logseq"
  :help/block-reference                              "Referència de bloc"
  :help/blog                                         "Blog de Logseq"

--- a/src/resources/dicts/cs.edn
+++ b/src/resources/dicts/cs.edn
@@ -96,7 +96,7 @@
  :help/title-about                                 "O nás"
  :help/title-terms                                 "Podmínky"
  :help/start                                       "Začínáme"
- :help/about                                       "O Logseq"
+ :help/about                                       "O Kip"
  :help/roadmap                                     "Plán činnosti"
  :help/bug                                         "Nahlásit chybu"
  :help/feature                                     "Požadovat novou funkci"

--- a/src/resources/dicts/de.edn
+++ b/src/resources/dicts/de.edn
@@ -191,7 +191,7 @@
  :header/search "Suchen"
  :header/toggle-left-sidebar "Linke Seitenleiste umschalten"
 
- :help/about "Über Logseq"
+ :help/about "Über Kip"
  :help/block-reference "Blockverweis"
  :help/blog "Logseq Blog"
  :help/bug "Fehlerbericht"

--- a/src/resources/dicts/es.edn
+++ b/src/resources/dicts/es.edn
@@ -370,7 +370,7 @@
  :header/more                                       "Más"
  :header/search                                     "Buscar"
  :header/toggle-left-sidebar                        "Alternar barra lateral izquierda"
- :help/about                                        "Acerca de Logseq"
+ :help/about                                        "Acerca de Kip"
  :help/awesome-logseq                               "Increíble Logseq"
  :help/block-reference                              "Referencia de bloque"
  :help/blog                                         "Blog de Logseq"

--- a/src/resources/dicts/fa.edn
+++ b/src/resources/dicts/fa.edn
@@ -72,7 +72,7 @@
  :help/title-about            "درباره"
  :help/title-terms            "قوانین"
  :help/start                  "شروع"
- :help/about                  "درباره لاگ‌سیک"
+ :help/about                  "درباره کیپ"
  :help/roadmap                "مسیر توسعه"
  :help/bug                    "گزارش مشکل"
  :help/feature                "درخواست ویژگی"

--- a/src/resources/dicts/fr.edn
+++ b/src/resources/dicts/fr.edn
@@ -1,7 +1,7 @@
 {
     :tutorial/text #resource "tutorials/tutorial-fr.md"
     :tutorial/dummy-notes #resource "tutorials/dummy-notes-fr.md"
-    :help/about "À propos de Logseq"
+    :help/about "À propos de Kip"
     :help/bug "Signaler une anomalie"
     :help/feature "Demander une fonctionnalité"
     :help/changelog "Journal des modifications"

--- a/src/resources/dicts/id.edn
+++ b/src/resources/dicts/id.edn
@@ -88,7 +88,7 @@
  :help/title-about "Tentang"
  :help/title-terms "Ketentuan"
  :help/start "Memulai"
- :help/about "Tentang Logseq"
+ :help/about "Tentang Kip"
  :help/roadmap "Peta jalan"
  :help/bug "Laporan bug"
  :help/feature "Permintaan fitur"

--- a/src/resources/dicts/it.edn
+++ b/src/resources/dicts/it.edn
@@ -9,7 +9,7 @@
  :on-boarding/new-graph-desc-4 "/pages - contiene le altre pagine"
  :on-boarding/new-graph-desc-5 "/logseq - contiene i dati di configurazione, custom.css, e alcuni metadati."
  :help/start "Per iniziare"
- :help/about "Informazioni su Logseq"
+ :help/about "Informazioni su Kip"
  :help/bug "Segnala un problema"
  :help/feature "Richiedi una funzionalità"
  :help/changelog "Registro delle modifiche"

--- a/src/resources/dicts/ja.edn
+++ b/src/resources/dicts/ja.edn
@@ -96,7 +96,7 @@
  :help/title-about "私たちについて"
  :help/title-terms "規約"
  :help/start "はじめに"
- :help/about "Logseqについて"
+ :help/about "Kipについて"
  :help/roadmap "ロードマップ"
  :help/bug "バグ報告"
  :help/feature "機能リクエスト"

--- a/src/resources/dicts/ko.edn
+++ b/src/resources/dicts/ko.edn
@@ -9,7 +9,7 @@
  :on-boarding/new-graph-desc-4 "/pages - 기타 페이지들을 저장합니다."
  :on-boarding/new-graph-desc-5 "/logseq - 사용자 설정과 custom.css, 그리고 몇 가지 메타데이터를 저장합니다."
  :help/start "시작"
- :help/about "Logseq에 대하여"
+ :help/about "Kip에 대하여"
  :help/roadmap "로드맵"
  :help/bug "오류 제보"
  :help/feature "기능 제안"

--- a/src/resources/dicts/nb-no.edn
+++ b/src/resources/dicts/nb-no.edn
@@ -9,7 +9,7 @@
  :on-boarding/new-graph-desc-4 "/pages - lagrer andre sider"
  :on-boarding/new-graph-desc-5 "/logseq - lagrer konfigurasjon, custom.css og noe metadata."
  :help/start "Kom i gang"
- :help/about "Om Logseq"
+ :help/about "Om Kip"
  :help/roadmap "Veikart"
  :help/bug "Feilrapport"
  :help/feature "Funksjonsforespørsel"

--- a/src/resources/dicts/nl.edn
+++ b/src/resources/dicts/nl.edn
@@ -79,7 +79,7 @@
  :graph/save-error "Opslaan mislukt"
  :graph/save-success "Opslaan succesvol"
 
- :help/about "Over Logseq"
+ :help/about "Over Kip"
  :help/block-reference "Blok referentie"
  :help/bug "Rapporteer een fout"
  :help/changelog "Verander logboek"

--- a/src/resources/dicts/pl.edn
+++ b/src/resources/dicts/pl.edn
@@ -9,7 +9,7 @@
  :on-boarding/new-graph-desc-4 "/pages - przechowuje wszystkie pozostałe, utworzone przez Ciebie strony"
  :on-boarding/new-graph-desc-5 "/logseq - przechowuje konfigurację, custom.css oraz niektóre meta dane."
  :help/start "Rozpocznij swoją przygodę z Logseq"
- :help/about "O Logseq"
+ :help/about "O Kip"
  :help/roadmap "Plany rozwoju"
  :help/bug "Zgłoś błąd"
  :help/feature "Zgłoś zapotrzebowanie na funkcjonalność"

--- a/src/resources/dicts/pt-br.edn
+++ b/src/resources/dicts/pt-br.edn
@@ -95,7 +95,7 @@
  :help/title-about "Sobre"
  :help/title-terms "Termos"
  :help/start "Começando"
- :help/about "Sobre o Logseq"
+ :help/about "Sobre o Kip"
  :help/roadmap "Roteiro"
  :help/bug "Relatório de bug"
  :help/feature "Solicitação de recurso"

--- a/src/resources/dicts/pt-pt.edn
+++ b/src/resources/dicts/pt-pt.edn
@@ -16,7 +16,7 @@
  :on-boarding/tour-whiteboard-new "{1} Criar um novo quadro branco"
  :on-boarding/tour-whiteboard-new-description "Existem múltiplas formas de criar um novo quadro branco. Uma delas está sempre aqui mesmo no painel."
  :help/start "Começar a usar"
- :help/about "Sobre o Logseq"
+ :help/about "Sobre o Kip"
  :help/roadmap "Plano de implementação"
  :help/bug "Reportar um erro"
  :help/feature "Pedir uma funcionalidade"

--- a/src/resources/dicts/ru.edn
+++ b/src/resources/dicts/ru.edn
@@ -23,7 +23,7 @@
  :help/title-about                                     "О нас"
  :help/title-terms                                     "Условия и положения"
  :help/start                                           "Начало работы"
- :help/about                                           "О Logseq"
+ :help/about                                           "О Kip"
  :help/roadmap                                         "Дорожная карта"
  :help/bug                                             "Сообщить об ошибке"
  :help/feature                                         "Предложить улучшение"

--- a/src/resources/dicts/sk.edn
+++ b/src/resources/dicts/sk.edn
@@ -96,7 +96,7 @@
  :help/title-about                                 "O nás"
  :help/title-terms                                 "Podmienky"
  :help/start                                       "Začíname"
- :help/about                                       "O Logseq"
+ :help/about                                       "O Kip"
  :help/roadmap                                     "Plán vývoja"
  :help/bug                                         "Nahlásiť chybu"
  :help/feature                                     "Požadovať novú funkciu"

--- a/src/resources/dicts/tr.edn
+++ b/src/resources/dicts/tr.edn
@@ -96,7 +96,7 @@
  :help/title-about "Hakkında"
  :help/title-terms "Koşullar"
  :help/start "Başlarken"
- :help/about "Logseq hakkında"
+ :help/about "Kip hakkında"
  :help/roadmap "Yol haritası"
  :help/bug "Hata raporu"
  :help/feature "Özellik istekleri"

--- a/src/resources/dicts/uk.edn
+++ b/src/resources/dicts/uk.edn
@@ -18,7 +18,7 @@
  :on-boarding/tour-whiteboard-new "{1} Створити нову дошку"
  :on-boarding/tour-whiteboard-new-description "Існує кілька способів створення нової дошки. Один із них завжди тут, на інформаційній панелі."
  :help/start "Починаємо"
- :help/about "Про Logseq"
+ :help/about "Про Kip"
  :help/roadmap "План розробки"
  :help/bug "Повідомлення про помилку"
  :help/feature "Запит функції"

--- a/src/resources/dicts/zh-cn.edn
+++ b/src/resources/dicts/zh-cn.edn
@@ -40,7 +40,7 @@
 
  :help/start "入门"
  :help/roadmap "路线图"
- :help/about "关于 Logseq"
+ :help/about "关于 Kip"
  :help/bug "Bug 反馈"
  :help/feature "功能建议"
  :help/changelog "更新日志"

--- a/src/resources/dicts/zh-hant.edn
+++ b/src/resources/dicts/zh-hant.edn
@@ -16,7 +16,7 @@
  :on-boarding/tour-whiteboard-new "{1} 創建新白板"
  :on-boarding/tour-whiteboard-new-description "除了這裡還有很多方法能創建新白板，詳閱 LogSeq 文件。"
  :help/start "入門"
- :help/about "關於 Logseq"
+ :help/about "關於 Kip"
  :help/roadmap "路線圖"
  :help/bug "問題回報"
  :help/feature "功能建議"

--- a/src/test/frontend/context/i18n_test.cljs
+++ b/src/test/frontend/context/i18n_test.cljs
@@ -10,11 +10,11 @@
 (deftest translations
   (testing "ui translations"
     (state/set-preferred-language! :en)
-    (is (= "About Logseq"
+    (is (= "About Kip"
            (i18n/t :help/about)))
 
     (state/set-preferred-language! :es)
-    (is (= "Acerca de Logseq"
+    (is (= "Acerca de Kip"
            (i18n/t :help/about))))
 
   (testing "command and category translations"


### PR DESCRIPTION
The rebrand ("de-Logseq the maintainer-facing bits") changed `:help/about` in `en.edn` to "About Kip" but left the other 22 locale files reading "About Logseq" / "Über Logseq" / "关于 Logseq" / …, and `frontend.context.i18n-test` still asserted `"About Logseq"` — so the test suite failed.

- `:help/about` value updated to the app name "Kip" in every dict (`fa` uses the Persian transliteration "کیپ")
- test assertions updated (`en` → "About Kip", `es` → "Acerca de Kip")

Other "Logseq" strings that genuinely name Logseq the project/service are left alone: importing a Logseq graph, "Awesome Logseq", Logseq Sync, the Logseq blog.

**Testing:** full suite green — `Ran 201 tests containing 1702 assertions. 0 failures, 0 errors.` (was 1 failure before.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)