### PR TITLE
Add a polite in-app update check

### DIFF
--- a/src/electron/electron/core.cljs
+++ b/src/electron/electron/core.cljs
@@ -2,6 +2,7 @@
   (:require [electron.handler :as handler]
             [electron.search :as search]
             [electron.updater :refer [init-updater] :as updater]
+            [electron.update :as app-update]
             [electron.utils :refer [*win mac? linux? dev? get-win-from-sender
                                     decode-protected-assets-schema-path get-graph-name send-to-renderer]
              :as utils]
@@ -40,11 +41,12 @@
 ;; Handle creating/removing shortcuts on Windows when installing/uninstalling.
 (when (js/require "electron-squirrel-startup") (.quit app))
 
-(defn setup-updater! [^js _win]
-  ;; Kip is a personal fork with no release feed — the auto-updater is
-  ;; disabled. (Upstream pointed init-updater at logseq/logseq, which would
-  ;; offer to "update" Kip to stock Logseq.)
-  nil)
+(defn setup-updater! [^js win]
+  ;; The electron-updater auto-install path (electron.updater) stays disabled —
+  ;; it needs signed binaries and a release feed. This is just the polite check:
+  ;; ask GitHub on launch + every 24h and let the renderer show a "new version"
+  ;; banner. Returns a teardown fn.
+  (app-update/start! win))
 
 (defn open-url-handler
   "win - the main window instance (first renderer process)

--- a/src/electron/electron/handler.cljs
+++ b/src/electron/electron/handler.cljs
@@ -28,6 +28,7 @@
             [electron.server :as server]
             [electron.shell :as shell]
             [electron.state :as state]
+            [electron.update :as update]
             [electron.utils :as utils]
             [electron.wiki :as wiki]
             [electron.window :as win]
@@ -553,6 +554,9 @@
 
 (defmethod handle :wikiCoopCounts [_ [_ vault-root]]
   (wiki/coop-counts! vault-root))
+
+(defmethod handle :checkForAppUpdate [_ [_ force?]]
+  (update/check! {:force? (boolean force?)}))
 
 (defmethod handle :wikiChat [_ [_ vault-root question trace?]]
   (wiki/peck! vault-root question (boolean trace?)))

--- a/src/electron/electron/update.cljs
+++ b/src/electron/electron/update.cljs
@@ -1,0 +1,82 @@
+(ns electron.update
+  "A polite in-app update check for Kip. Not the electron-updater auto-install
+  path (electron.updater — disabled, needs signed binaries): this just asks
+  GitHub once on launch and every 24h whether a newer release exists, and lets
+  the renderer show a dismissible banner. No download, no install."
+  (:require ["semver" :as semver]
+            [cljs-bean.core :as bean]
+            [clojure.string :as string]
+            [electron.configs :as cfgs]
+            [electron.logger :as logger]
+            [electron.utils :as utils]
+            [frontend.version :refer [version]]
+            [promesa.core :as p]))
+
+(def ^:private releases-url
+  "https://api.github.com/repos/JWE24-code/kip-app/releases/latest")
+
+(def ^:private check-interval-ms (* 24 60 60 1000))
+(def ^:private timeout-ms 5000)
+;; Stored in configs.edn (electron.configs) so it survives restarts.
+(def ^:private cache-key :update/last-check)
+
+(defn- strip-v [tag]
+  (some-> tag (string/replace #"^[vV]" "")))
+
+(defn- newer?
+  "Is `latest-tag` (e.g. \"v0.3.1\") a higher semver than the running build?"
+  [latest-tag]
+  (let [l (strip-v latest-tag)]
+    (boolean (and l (semver/valid l) (semver/valid version) (semver/gt l version)))))
+
+(defn- fetch-latest! []
+  (-> (utils/fetch releases-url
+                   {:timeout timeout-ms
+                    :headers {"Accept"     "application/vnd.github+json"
+                              "User-Agent" (str "Kip/" version)}})
+      (p/then (fn [^js res]
+                (if (.-ok res)
+                  (.json res)
+                  (p/rejected (js/Error. (str "GitHub returned " (.-status res)))))))
+      (p/then (fn [json]
+                (let [{:keys [tag_name html_url body]} (bean/->clj json)]
+                  {:latest tag_name :url html_url :notes body})))))
+
+(defn check!
+  "Resolve to a plain JS object {current, latest, url, notes, newer?} — a JS
+  object, not a CLJS map, because the result crosses the ipcMain.handle
+  structured-clone boundary. Uses a 24h cache in configs.edn unless `force?`.
+  Any failure (offline, timeout, rate limit) resolves to {current, newer?:
+  false} — a failed check is never an error the user sees."
+  ([] (check! {}))
+  ([{:keys [force?]}]
+   (let [cached (cfgs/get-item cache-key)
+         fresh? (and (map? cached)
+                     (number? (:at cached))
+                     (< (- (js/Date.now) (:at cached)) check-interval-ms))]
+     (if (and fresh? (not force?))
+       (p/resolved (clj->js (dissoc cached :at)))
+       (-> (fetch-latest!)
+           (p/then (fn [{:keys [latest url notes]}]
+                     (let [result {:current version
+                                   :latest  latest
+                                   :url     url
+                                   :notes   notes
+                                   :newer?  (newer? latest)}]
+                       (cfgs/set-item! cache-key (assoc result :at (js/Date.now)))
+                       (clj->js result))))
+           (p/catch (fn [err]
+                      (logger/warn "[update] check failed:" (.-message err))
+                      #js {:current version :newer? false})))))))
+
+(defn start!
+  "Check on launch, then every 24h; push :app-update-available to `win`
+  whenever a newer version is found. Returns a teardown fn."
+  [^js win]
+  (let [run  #(-> (check! {})
+                  (p/then (fn [^js r]
+                            (when (aget r "newer?")
+                              (utils/send-to-renderer win :app-update-available r)))))
+        _    (run)
+        id   (js/setInterval run check-interval-ms)]
+    #(js/clearInterval id)))

--- a/src/main/frontend/components/header.cljs
+++ b/src/main/frontend/components/header.cljs
@@ -11,6 +11,7 @@
             [frontend.config :as config]
             [frontend.context.i18n :refer [t]]
             [frontend.handler :as handler]
+            [frontend.handler.update :as update-handler]
             [frontend.handler.file-sync :as file-sync-handler]
             [frontend.components.file-sync :as fs-sync]
             [frontend.handler.plugin :as plugin-handler]
@@ -220,6 +221,32 @@
          {:on-click #(handler/quit-and-install-new-version!)}
          (svg/reload 16) [:strong (t :updater/quit-and-install)]]]])))
 
+(defn- on-update-push [_ args]
+  (state/set-state! :kip/update (assoc (bean/->clj args) :checking? false)))
+
+;; A dismissible "a newer Kip is out" strip in the header — the polite update
+;; check (frontend.handler.update / electron.update). No download/install here;
+;; it just links to the release page.
+(rum/defcs app-update-banner
+  < rum/reactive
+  {:did-mount    (fn [state]
+                   (update-handler/check! false)
+                   (when (util/electron?)
+                     (js/apis.addListener "app-update-available" on-update-push))
+                   state)
+   :will-unmount (fn [state]
+                   (when (util/electron?)
+                     (js/apis.removeListener "app-update-available" on-update-push))
+                   state)}
+  [_state]
+  (let [{:keys [latest url]} (state/sub :kip/update)]
+    (when (update-handler/show-banner?)
+      [:div.cp__header-tips
+       [:p
+        (str "Kip " latest " is available.")
+        [:a.ml-2 {:href url :target "_blank"} [:strong "See what's new"]]
+        [:a.ml-3.opacity-70 {:on-click #(update-handler/dismiss!)} "Dismiss"]]])))
+
 (rum/defc ^:large-vars/cleanup-todo header < rum/reactive
   [{:keys [open-fn current-repo default-home new-block-mode]}]
   (let [repos (->> (state/sub [:me :repos])
@@ -317,4 +344,5 @@
 
       (sidebar/toggle)
 
-      (updater-tips-new-version t)]]))
+      (updater-tips-new-version t)
+      (app-update-banner)]]))

--- a/src/main/frontend/components/settings.cljs
+++ b/src/main/frontend/components/settings.cljs
@@ -22,6 +22,7 @@
             [frontend.handler.plugin :as plugin-handler]
             [frontend.handler.route :as route-handler]
             [frontend.handler.ui :as ui-handler]
+            [frontend.handler.update :as update-handler]
             [frontend.handler.user :as user-handler]
             [frontend.mobile.util :as mobile-util]
             [frontend.modules.instrumentation.core :as instrument]
@@ -50,79 +51,40 @@
      (ui/toggle state on-toggle true)
      detail-text]]])
 
+(def ^:private releases-url "https://github.com/JWE24-code/kip-app/releases")
+
 (rum/defcs app-updater < rum/reactive
-  [state version]
-  (let [update-pending? (state/sub :electron/updater-pending?)
-        {:keys [type payload]} (state/sub :electron/updater)]
+  [_state version]
+  (let [{:keys [checking? newer? latest url]} (state/sub :kip/update)]
     [:span.cp__settings-app-updater
-
      [:div.ctls.flex.items-center
-
       [:div.mt-1.sm:mt-0.sm:col-span-2.flex.gap-4.items-center.flex-wrap
-       [:div (cond
-               (mobile-util/native-android?)
-               (ui/button
-                (t :settings-page/check-for-updates)
-                :class "text-sm mr-1"
-                :href "https://github.com/logseq/og/releases")
+       [:div
+        (if (util/electron?)
+          (ui/button
+           (if checking? (t :settings-page/checking) (t :settings-page/check-for-updates))
+           :class "text-sm mr-1"
+           :disabled (boolean checking?)
+           :on-click #(update-handler/check! true))
+          (ui/button
+           (t :settings-page/check-for-updates)
+           :class "text-sm mr-1"
+           :href releases-url))]
 
-               (mobile-util/native-ios?)
-               (ui/button
-                (t :settings-page/check-for-updates)
-                :class "text-sm mr-1"
-                :href "https://apps.apple.com/app/logseq/id1601013908")
-
-               (util/electron?)
-               (ui/button
-                (if update-pending? (t :settings-page/checking) (t :settings-page/check-for-updates))
-                :class "text-sm mr-1"
-                :disabled update-pending?
-                :on-click #(js/window.apis.checkForUpdates false))
-
-               :else
-               nil)]
-
-       [:div.text-sm.cursor
-        {:title (str (t :settings-page/revision) config/revision)
-         :on-click (fn []
-                     (notification/show! [:div "Current Revision: "
-                                          [:a {:target "_blank"
-                                               :href (str "https://github.com/logseq/logseq/commit/" config/revision)}
-                                           config/revision]]
-                                         :info
-                                         false))}
-        version]
+       [:div.text-sm version]
 
        [:a.text-sm.fade-link.underline.inline
         {:target "_blank"
-         :href "https://docs.logseq.com/#/page/changelog"}
+         :href "https://github.com/JWE24-code/kip/blob/main/CHANGELOG.md"}
         (t :settings-page/changelog)]]]
 
-     (when-not (or update-pending?
-                   (string/blank? type))
+     (when (and (util/electron?) (not checking?) (some? newer?))
        [:div.update-state.text-sm
-        (case type
-          "update-not-available"
-          [:p (t :settings-page/app-updated)]
-
-          "update-available"
-          (let [{:keys [name url]} payload]
-            [:p (str (t :settings-page/update-available))
-             [:a.link
-              {:on-click
-               (fn [e]
-                 (js/window.apis.openExternal url)
-                 (util/stop e))}
-              svg/external-link name " 🎉"]])
-
-          "error"
-          [:p (t :settings-page/update-error-1) [:br] (t :settings-page/update-error-2)
-           [:a.link
-            {:on-click
-             (fn [e]
-               (js/window.apis.openExternal "https://github.com/logseq/og/releases")
-               (util/stop e))}
-            svg/external-link " release channel"]])])]))
+        (if newer?
+          [:p (str "Kip " latest " is available — ")
+           [:a.link {:on-click (fn [e] (js/window.apis.openExternal url) (util/stop e))}
+            svg/external-link "download"]]
+          [:p (t :settings-page/app-updated)])])]))
 
 (rum/defc outdenting-hint
   []

--- a/src/main/frontend/handler/update.cljs
+++ b/src/main/frontend/handler/update.cljs
@@ -1,0 +1,45 @@
+(ns frontend.handler.update
+  "Renderer side of the polite update check (electron.update). Triggers the
+  check over IPC, caches the result in :kip/update, and tracks which version
+  the user has dismissed the banner for."
+  (:require [cljs-bean.core :as bean]
+            [electron.ipc :as ipc]
+            [frontend.state :as state]
+            [frontend.storage :as storage]
+            [frontend.util :as util]
+            [promesa.core :as p]))
+
+(def ^:private dismissed-key "kip-update-dismissed")
+
+(defn dismissed-version []
+  (storage/get dismissed-key))
+
+(defn dismiss!
+  "Hide the banner until a release newer than the current latest."
+  []
+  (when-let [latest (:latest (:kip/update @state/state))]
+    (storage/set dismissed-key latest)
+    (state/set-state! [:kip/update :dismissed?] true)))
+
+(defn show-banner?
+  "A newer version exists and the user hasn't dismissed the banner for it."
+  []
+  (let [{:keys [newer? latest dismissed?]} (:kip/update @state/state)]
+    (and newer? (not dismissed?) (not= latest (dismissed-version)))))
+
+(defn check!
+  "Run the check (force? bypasses the 24h cache in the main process) and store
+  the result. Never rejects."
+  ([] (check! false))
+  ([force?]
+   (when (util/electron?)
+     (state/set-state! [:kip/update :checking?] true)
+     (-> (ipc/ipc "checkForAppUpdate" force?)
+         (p/then (fn [r]
+                   (let [{:keys [latest] :as result} (bean/->clj r)]
+                     (state/set-state! :kip/update
+                                       (assoc result
+                                              :checking? false
+                                              :dismissed? (= latest (dismissed-version)))))))
+         (p/catch (fn [_]
+                    (state/set-state! [:kip/update :checking?] false)))))))

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -127,6 +127,10 @@
      ;; frontend.handler.coop/refresh-counts!.
      :kip/coop-counts                       {:loaded? false :eggs 0 :nestPages 0}
 
+     ;; Result of the polite update check (frontend.handler.update) —
+     ;; {:current :latest :url :notes :newer? :dismissed? :checking?}.
+     :kip/update                            {}
+
      :config                                {}
      :block/component-editing-mode?         false
      :editor/op                             nil


### PR DESCRIPTION
Implements #6.

### Problem
Kip ships as unsigned folder-zips. Nothing tells the user a newer release is out — you have to watch GitHub Releases and re-download by hand.

### Change
A **check on launch** (then every 24h) against `api.github.com/repos/JWE24-code/kip-app/releases/latest`, and a dismissible header strip:

> **Kip v0.2.0 is available.** — *See what's new* · *Dismiss*

No download, no install — the `electron.updater` auto-install path stays disabled (it needs signed binaries). This is just the nudge.

### Design (Option C from the #6 spec)
- **`electron.update`** (main): fetch `releases/latest` with a 5s timeout, compare `tag_name` to `frontend.version/version` via `semver`, cache the result 24h in `configs.edn`. Any failure (offline / timeout / rate-limit) resolves to `{newer?: false}` — never a user-visible error. Returns a **`#js` object** because the result crosses the `ipcMain.handle` structured-clone boundary (a CLJS map serializes as garbage there).
- **`:checkForAppUpdate`** IPC; `setup-updater!` now starts the 24h loop and pushes `:app-update-available` to the renderer.
- **`frontend.handler.update`** (renderer): runs the check, caches `:kip/update`, remembers the dismissed version in `localStorage` (dismiss v0.2.0 → silent until v0.2.1).
- **header**: the dismissible banner (`.cp__header-tips`, same style as the existing updater tip).
- **settings**: the existing (dead) "Check for updates" button now runs this check and shows *up to date* / *vX available → download*. Logseq links → Kip.

### Testing
Verified via the electron + renderer REPLs:
- fresh fetch, 24h-cache hit, and the failure path all return a clean JS object
- renderer: `:kip/update` populated correctly, banner renders in the DOM ("Kip v0.2.0 is available…"), `show-banner?` true
- **Dismiss** → `show-banner?` false, `kip-update-dismissed` = "v0.2.0" in localStorage, survives a re-check
- `newer?` via semver: equal / current-ahead → false; patch bump → true; handles the `v` prefix
- Full suite green: 201 tests / 1702 assertions / 0 failures
- Both builds compile with 0 warnings; clj-kondo clean

### Note
Because `version.cljs` is still `"0.1.0"` on `version/file`, a v0.2.0 build will show this banner until the version bump lands (flagged separately to kimi on #7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)