### PR TITLE
Hatch: an "Ask Kip about them" CTA after a run creates pages

### DIFF
--- a/src/main/frontend/components/chat.cljs
+++ b/src/main/frontend/components/chat.cljs
@@ -39,6 +39,12 @@
 (def ^:private *messages (rum/cursor-in *peck-session [:messages]))
 (def ^:private *input (rum/cursor-in *peck-session [:input]))
 
+(defn prefill!
+  "Drop `text` into the Peck input, ready for the user to send or edit. Used by
+  the post-hatch 'Ask Kip about them' CTA (see :peck/prefill in events)."
+  [text]
+  (swap! *peck-session assoc :input text))
+
 ;; Generic on purpose — these render in the empty state, so they must not
 ;; reference anything from the user's own nest.
 (def ^:private example-prompts

--- a/src/main/frontend/components/ingest.cljs
+++ b/src/main/frontend/components/ingest.cljs
@@ -162,11 +162,23 @@
        :else
        [:div
         (when (seq (:hatched done))
-          [:div.mb-3
-           [:h3.text-lg.font-medium.mb-1 (str "Hatched " (count (:hatched done)))]
-           [:ul.list-disc.pl-5
-            (for [[i it] (map-indexed vector (:hatched done))]
-              (rum/with-key (source-line it) i))]])
+          (let [new-slugs (->> (:hatched done)
+                               (mapcat :results)
+                               (filter #(= "create" (:action %)))
+                               (map :slug)
+                               distinct)]
+            [:div.mb-3
+             [:h3.text-lg.font-medium.mb-1 (str "Hatched " (count (:hatched done)))]
+             [:ul.list-disc.pl-5
+              (for [[i it] (map-indexed vector (:hatched done))]
+                (rum/with-key (source-line it) i))]
+             (when (and (not @*busy?) (seq new-slugs))
+               [:div.mt-2
+                (ui/button
+                 {:variant :outline :size :sm
+                  :on-click #(state/pub-event! [:peck/prefill
+                                                (str "What's in [[" (first new-slugs) "]]?")])}
+                 "Ask Kip about them →")])]))
 
         (when (seq (:failed done))
           [:div.mb-3

--- a/src/main/frontend/handler/events.cljs
+++ b/src/main/frontend/handler/events.cljs
@@ -19,6 +19,7 @@
             [frontend.components.diff :as diff]
             [frontend.components.encryption :as encryption]
             [frontend.components.file-sync :as file-sync]
+            [frontend.components.chat :as chat]
             [frontend.components.git :as git-component]
             [frontend.components.ingest :as ingest]
             [frontend.components.plugins :as plugin]
@@ -336,6 +337,11 @@
 
 (defmethod handle :modal/show-hatch [_]
   (state/set-modal! ingest/hatch-modal))
+
+(defmethod handle :peck/prefill [[_ text]]
+  (state/close-modal!)
+  (state/set-peck-mode! true)
+  (chat/prefill! text))
 
 (defmethod handle :modal/show-instruction [_]
   (state/set-modal! capacitor-fs/instruction {:id :instruction


### PR DESCRIPTION
Closes #14.

After a hatch run the modal listed the new pages and stopped there. Now, when a run created ≥1 nest page, it shows a button that **closes the modal, switches to Peck, and drops `What's in [[<new-page>]]?` into the prompt** — the new user's next move is obvious instead of "now what?".

- `chat/prefill!` — public: set the Peck input
- `:peck/prefill` event — close modal → enter Peck mode → prefill
- `ingest.cljs`: collect the created slugs from `done`, render the CTA

Verified in the dev app: `:peck/prefill` closes the modal, flips to Peck, and the prompt shows the question with the Peck button enabled. Suite green (201/0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)