### PR TITLE
Hatch: an "Add source…" file picker in the modal

### DIFF
--- a/src/electron/electron/handler.cljs
+++ b/src/electron/electron/handler.cljs
@@ -552,6 +552,9 @@
 (defmethod handle :wikiAddEgg [_ [_ vault-root filename content]]
   (wiki/add-egg! vault-root filename content))
 
+(defmethod handle :wikiPickEggs [_ [_ vault-root]]
+  (wiki/pick-and-add-eggs! vault-root))
+
 (defmethod handle :wikiCoopCounts [_ [_ vault-root]]
   (wiki/coop-counts! vault-root))
 

--- a/src/electron/electron/wiki.cljs
+++ b/src/electron/electron/wiki.cljs
@@ -195,6 +195,28 @@
             full (.join node-path eggs-dir nm)]
         (if (fs/existsSync full) (recur (inc n)) [nm full])))))
 
+(defn- write-egg-content
+  "Sync core: validate the extension, skip a byte-identical file already in
+  `eggs-dir`, otherwise write `content` under a non-colliding name. Returns a
+  CLJS map: {:ok true :name ...} / {:ok true :name ... :duplicate ...} /
+  {:ok false :reason ...}."
+  [eggs-dir basename content]
+  (let [ext (string/lower-case (or (.extname node-path basename) ""))]
+    (if-not (contains? egg-extensions ext)
+      {:ok false :reason "unsupported" :ext ext}
+      (do
+        (fs/mkdirSync eggs-dir #js {:recursive true})
+        (if-let [dup (->> (fs/readdirSync eggs-dir)
+                          (filter (fn [nm]
+                                    (let [p (.join node-path eggs-dir nm)]
+                                      (and (try (.isFile (fs/statSync p)) (catch :default _ false))
+                                           (= content (fs/readFileSync p "utf8"))))))
+                          first)]
+          {:ok true :name dup :duplicate dup}
+          (let [[nm full] (unique-egg-path eggs-dir basename)]
+            (fs/writeFileSync full content "utf8")
+            {:ok true :name nm}))))))
+
 (defn add-egg!
   "Write `content` (a dropped file's text) into <graph>/eggs/ under `filename`,
   so it becomes a Hatch source. Resolves:
@@ -207,32 +229,40 @@
   (p/create
    (fn [resolve* _reject]
      (try
-       (let [ext (when (string? filename)
-                   (string/lower-case (.extname node-path filename)))]
-         (cond
-           (or (string/blank? vault-root) (string/blank? filename))
-           (resolve* #js {:ok false :reason "no-graph"})
-
-           (not (contains? egg-extensions ext))
-           (resolve* #js {:ok false :reason "unsupported" :ext (or ext "")})
-
-           :else
-           (let [eggs-dir (.join node-path vault-root "eggs")
-                 _ (fs/mkdirSync eggs-dir #js {:recursive true})
-                 dup (->> (fs/readdirSync eggs-dir)
-                          (filter (fn [nm]
-                                    (let [p (.join node-path eggs-dir nm)]
-                                      (and (try (.isFile (fs/statSync p)) (catch :default _ false))
-                                           (= content (fs/readFileSync p "utf8"))))))
-                          first)]
-             (if dup
-               (resolve* #js {:ok true :name dup :duplicate dup})
-               (let [[nm full] (unique-egg-path eggs-dir (.basename node-path filename))]
-                 (fs/writeFileSync full content "utf8")
-                 (resolve* #js {:ok true :name nm}))))))
+       (if (or (string/blank? vault-root) (string/blank? filename))
+         (resolve* #js {:ok false :reason "no-graph"})
+         (resolve* (clj->js (write-egg-content (.join node-path vault-root "eggs")
+                                               (.basename node-path filename)
+                                               content))))
        (catch :default e
          (log-error (str "add-egg! " filename ": " (.-message e)))
          (resolve* #js {:ok false :reason (.-message e)}))))))
+
+(defn pick-and-add-eggs!
+  "Open a native file picker (Markdown / text, multi-select) and copy the
+  chosen files into <graph>/eggs/. Resolves
+  {:canceled bool :added [names] :duplicates [names] :rejected [names]}."
+  [vault-root]
+  (p/let [^js res (.showOpenDialog dialog
+                                   #js {:title "Add sources to your coop"
+                                        :properties #js ["openFile" "multiSelections"]
+                                        :filters #js [#js {:name "Markdown / text"
+                                                           :extensions #js ["md" "markdown" "mdown" "txt" "text" "org"]}]})
+          paths (or (some-> res .-filePaths array-seq) [])]
+    (if (or (string/blank? vault-root) (empty? paths))
+      #js {:canceled true :added #js [] :duplicates #js [] :rejected #js []}
+      (let [eggs-dir (.join node-path vault-root "eggs")
+            results  (mapv (fn [path]
+                             (try
+                               (write-egg-content eggs-dir (.basename node-path path)
+                                                  (fs/readFileSync path "utf8"))
+                               (catch :default e
+                                 {:ok false :reason (.-message e) :name (.basename node-path path)})))
+                           paths)]
+        (clj->js {:canceled   false
+                  :added      (->> results (filter #(and (:ok %) (not (:duplicate %)))) (mapv :name))
+                  :duplicates (->> results (filter :duplicate) (mapv :name))
+                  :rejected   (->> results (remove :ok) (mapv #(or (:name %) "a file")))})))))
 
 (defn- count-files
   "Count of files under `dir` (recursively) matching `pred` (a fn of the

--- a/src/main/frontend/components/ingest.cljs
+++ b/src/main/frontend/components/ingest.cljs
@@ -19,6 +19,7 @@
             [frontend.config :as config]
             [frontend.handler.coop :as coop]
             [frontend.handler.llm :as llm-handler]
+            [frontend.handler.notification :as notification]
             [frontend.state :as state]
             [frontend.util :as util]
             [promesa.core :as p]
@@ -37,6 +38,26 @@
       (p/then (fn [r] (reset! *preview (bean/->clj r))))
       (p/catch (fn [e] (reset! *error (str e))))
       (p/finally (fn [] (reset! *busy? false)))))
+
+(defn- pick-eggs! [*preview *error *busy?]
+  (-> (ipc/ipc "wikiPickEggs" (vault-root))
+      (p/then (fn [r]
+                (let [{:keys [canceled added duplicates rejected]} (bean/->clj r)]
+                  (when-not canceled
+                    (when (seq added)
+                      (notification/show!
+                       (str "Added " (string/join ", " added) " to eggs/.") :success true))
+                    (when (seq duplicates)
+                      (notification/show!
+                       (str (string/join ", " duplicates) " already in your coop.") :info true))
+                    (when (seq rejected)
+                      (notification/show!
+                       (str "Skipped " (count rejected) " file(s) — Kip reads Markdown and text only.")
+                       :warning true))
+                    (when (or (seq added) (seq duplicates))
+                      (coop/refresh-counts!)
+                      (load-preview! *preview *error *busy?))))))
+      (p/catch (fn [e] (notification/show! (str "Couldn't add sources: " e) :error true)))))
 
 (defn- start-poll! [*progress *poll-id]
   (let [tick #(-> (ipc/ipc "wikiIngestProgress" (vault-root))
@@ -137,6 +158,13 @@
       "Turns new or changed files in " [:code "eggs/"] ", " [:code "journals/"] " and "
       [:code "pages/"] " into nest pages — no per-file review. Runs in batches of "
       (str batch-size) "."]
+
+     (when-not @*busy?
+       [:div.mb-3
+        (ui/button {:variant :outline :size :sm
+                    :on-click #(pick-eggs! *preview *error *busy?)}
+                   "Add source…")
+        [:span.text-xs.opacity-50.ml-2 "or drop a file here"]])
 
      (llm-banner/provider-banner)
 


### PR DESCRIPTION
Closes #11.

The only in-app way to add a Hatch source was drag-and-drop (#2). The Hatch modal now has an **"Add source…"** button that opens a native multi-select file picker (Markdown / text) and copies the chosen files into `eggs/`, then refreshes the pending list.

- `electron.wiki`: extracted `write-egg-content` (the shared sync core: ext check, byte-identical dedup, non-colliding name); `add-egg!` (#2) is now a thin wrapper over it. New `pick-and-add-eggs!` (native `showOpenDialog` + copy) behind `:wikiPickEggs`.
- `ingest.cljs`: the button + a result notification (added / already-there / skipped-non-text) + preview + coop-count refresh.

Verified: `add-egg!` still returns correct results after the refactor (new / byte-identical duplicate / unsupported ext); the button renders in the modal; both builds compile 0 warnings. The native picker itself can't be driven headlessly, but the write path is the tested `write-egg-content` and the dialog call mirrors the existing `open-dir-dialog`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)