### PR TITLE
Settings → LLM: live reachability check for a Local endpoint

### DIFF
--- a/src/electron/electron/handler.cljs
+++ b/src/electron/electron/handler.cljs
@@ -507,6 +507,9 @@
 (defmethod handle :testLlmConnection [_ [_ candidate]]
   (llm/test-llm-connection! candidate))
 
+(defmethod handle :probeLocalLlm [_ [_ base-url]]
+  (llm/probe-local! base-url))
+
 (defmethod handle :skillsList [_ [_ vault-root]]
   (skills/list! vault-root))
 

--- a/src/electron/electron/llm.cljs
+++ b/src/electron/electron/llm.cljs
@@ -11,8 +11,10 @@
   Node and Electron's bundled Node at once. llm.js itself only touches the
   filesystem and fetch — no native deps — so it stays here."
   (:require [cljs-bean.core :as bean]
+            [clojure.string :as string]
             ["path" :as node-path]
-            [electron.wiki :as wiki]))
+            [electron.wiki :as wiki]
+            [promesa.core :as p]))
 
 (def llm-lib (js/require (.join node-path wiki/scripts-dir "lib" "llm.js")))
 
@@ -36,3 +38,36 @@
   to {success true/false, reply/error}."
   [candidate]
   (.testConnection llm-lib (bean/->js candidate)))
+
+(defn probe-local!
+  "GET <base-url>/models — Ollama serves it at its OpenAI-compatible path, as
+  does any OpenAI-compatible local server. Resolves a JS object
+  {ok bool, models [ids], error str}. 3s timeout; a failed probe is not an
+  error the user should see as a stack trace.
+
+  Uses the Node global fetch (no proxy agent) — a localhost endpoint must not
+  be routed through a system HTTP proxy."
+  [base-url]
+  (if (string/blank? base-url)
+    (p/resolved #js {:ok false :error "Set a base URL first."})
+    (-> (js/fetch (str (string/replace base-url #"/+$" "") "/models")
+                  #js {:signal (js/AbortSignal.timeout 3000)})
+        (p/then (fn [^js res]
+                  (if (.-ok res)
+                    (p/then (.json res)
+                            (fn [j]
+                              (let [models (->> (:data (bean/->clj j)) (keep :id) sort vec)]
+                                #js {:ok true :models (clj->js models)})))
+                    #js {:ok false :error (str "Server responded " (.-status res) ".")})))
+        (p/catch (fn [^js e]
+                   ;; global fetch wraps the real network error in e.cause
+                   (let [name (str (.-name e))
+                         code (str (some-> e .-cause .-code))
+                         msg  (str (.-message e))]
+                     #js {:ok false
+                          :error (cond
+                                   (= name "TimeoutError")     "No response — is the server running?"
+                                   (= code "ECONNREFUSED")     "Nothing is listening there — start it (e.g. `ollama serve`)."
+                                   (contains? #{"ENOTFOUND" "EAI_AGAIN"} code) "Can't resolve that host."
+                                   (string/blank? msg)         "Couldn't reach it."
+                                   :else                       msg)}))))))

--- a/src/main/frontend/components/llm_settings.cljs
+++ b/src/main/frontend/components/llm_settings.cljs
@@ -63,6 +63,22 @@
         (p/catch (fn [err] (reset! *save-message {:type :error :text (str err)})))
         (p/finally (fn [] (reset! *saving? false))))))
 
+(defn- probe-local!
+  "Ping the local endpoint's /models and stash {:status :checking/:ok/:down
+  :models [...] :error ...} in *probe. No-op unless the current provider is
+  `local`."
+  [*provider *fields *probe]
+  (when (= :local @*provider)
+    (let [base-url (get-in @*fields [:local :baseUrl])]
+      (reset! *probe {:status :checking})
+      (-> (ipc/ipc "probeLocalLlm" base-url)
+          (p/then (fn [r]
+                    (let [{:keys [ok models error]} (bean/->clj r)]
+                      (reset! *probe (if ok
+                                       {:status :ok :models (vec models)}
+                                       {:status :down :error error})))))
+          (p/catch (fn [err] (reset! *probe {:status :down :error (str err)})))))))
+
 (defn- test-connection!
   [*provider *fields *testing? *test-result]
   (reset! *testing? true)
@@ -84,8 +100,15 @@
   (rum/local nil ::save-message)
   (rum/local false ::testing?)
   (rum/local nil ::test-result)
+  (rum/local nil ::probe)
   {:will-mount (fn [state]
                  (load-config! (get state ::provider) (get state ::fields) (get state ::loaded?))
+                 state)
+   :did-update (fn [state]
+                 (when (and @(get state ::loaded?)
+                            (= :local @(get state ::provider))
+                            (nil? @(get state ::probe)))
+                   (probe-local! (get state ::provider) (get state ::fields) (get state ::probe)))
                  state)}
   [state]
   (let [*provider (get state ::provider)
@@ -95,6 +118,7 @@
         *save-message (get state ::save-message)
         *testing? (get state ::testing?)
         *test-result (get state ::test-result)
+        *probe (get state ::probe)
         provider (or @*provider :anthropic)
         fields (get @*fields provider (empty-provider-fields))
         show-base-url? (contains? providers-with-base-url provider)]
@@ -108,8 +132,11 @@
           {:id "llm-provider"
            :value (name provider)
            :on-change (fn [e]
-                        (reset! *provider (keyword (util/evalue e)))
-                        (reset! *test-result nil))}
+                        (let [p (keyword (util/evalue e))]
+                          (reset! *provider p)
+                          (reset! *test-result nil)
+                          (reset! *probe nil)
+                          (when (= p :local) (probe-local! *provider *fields *probe))))}
           (for [{:keys [value label]} providers]
             [:option {:key value :value value} label])]]
 
@@ -140,7 +167,25 @@
              :type "text"
              :value (:baseUrl fields)
              :placeholder "http://localhost:11434/v1"
-             :on-change (fn [e] (swap! *fields assoc-in [provider :baseUrl] (util/evalue e)))}]])
+             :on-change (fn [e] (swap! *fields assoc-in [provider :baseUrl] (util/evalue e)))
+             :on-blur (fn [_] (when (= provider :local) (probe-local! *provider *fields *probe)))}]
+           (when (= provider :local)
+             (let [{:keys [status models error]} @*probe]
+               [:div.text-xs.mt-1
+                (case status
+                  :checking [:span.opacity-60 "Checking…"]
+                  :ok       [:span
+                             [:span.text-green-500 "● Reachable"]
+                             (when (seq models)
+                               [:span.opacity-70
+                                (str " · " (count models) (if (= 1 (count models)) " model: " " models: "))
+                                (interpose ", "
+                                           (for [m models]
+                                             [:a.underline {:key m
+                                                            :on-click #(swap! *fields assoc-in [:local :model] m)}
+                                              m]))])]
+                  :down     [:span.text-red-500 (str "● " error)]
+                  nil)]))])
 
         [:div.text-xs.opacity-50.my-3
          "Stored in plaintext at .henhouse/llm.json inside your graph folder "


### PR DESCRIPTION
Closes #13.

Picking **"Local (Ollama)"** gave no feedback until you saved and a Hatch/Peck call failed. The Base URL field now shows a live status:

- `● Reachable · 3 models: llama3.1, mistral, …` — each model is clickable to fill the Model field
- `● Nothing is listening there — start it (e.g. `ollama serve`).`
- `● Server responded 404.` / `● No response — is the server running?`

**Details**
- `electron.llm/probe-local!` — `GET <base>/models` via the **Node global fetch** (not `utils/fetch`, which routes through the system HTTP proxy — a localhost endpoint must not). 3s `AbortSignal.timeout`. Classifies `ECONNREFUSED` / `TimeoutError` / DNS / HTTP status into a short message. `:probeLocalLlm` IPC.
- `llm_settings.cljs` — probes on mount (if local), on switching to Local, and on Base URL blur; renders the status line + model list.

**Testing**
`probe-local!` verified via the electron REPL: empty URL → "Set a base URL first."; Ollama down → the ECONNREFUSED message; a non-LLM service → "Server responded 404." UI shows the status line (confirmed the empty-URL state on screen). The reachable+models render is a `case` on the probe result. Both builds 0 warnings; clj-kondo clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)