### PR TITLE
Coop status: a "Your coop" overview at the top

### DIFF
--- a/src/electron/electron/handler.cljs
+++ b/src/electron/electron/handler.cljs
@@ -555,6 +555,9 @@
 (defmethod handle :wikiCoopCounts [_ [_ vault-root]]
   (wiki/coop-counts! vault-root))
 
+(defmethod handle :wikiCoopSummary [_ [_ vault-root]]
+  (wiki/coop-summary! vault-root))
+
 (defmethod handle :checkForAppUpdate [_ [_ force?]]
   (update/check! {:force? (boolean force?)}))
 

--- a/src/electron/electron/wiki.cljs
+++ b/src/electron/electron/wiki.cljs
@@ -259,6 +259,34 @@
                                               #(and (= ".md" (string/lower-case (.extname node-path %)))
                                                     (not= "index.md" (.basename node-path %))))})))))
 
+(defn- md-file? [p]
+  (= ".md" (string/lower-case (.extname node-path p))))
+
+(defn- metrics-at
+  "The ms-epoch :at from a .roost/<file>-metrics.json, or nil."
+  [vault-root file]
+  (try
+    (.-at (js/JSON.parse (fs/readFileSync (roost-file vault-root file) "utf8")))
+    (catch :default _ nil)))
+
+(defn coop-summary!
+  "A read-only snapshot of the open coop for the 'Your coop' panel: sources in
+  eggs/, nest pages by type, and the last hatch / last groom times (ms epoch,
+  nil if never). Plain fs reads — no subprocess."
+  [vault-root]
+  (p/create
+   (fn [resolve* _reject]
+     (if (string/blank? vault-root)
+       (resolve* #js {})
+       (let [nest (.join node-path vault-root "nest")]
+         (resolve* #js {:eggs        (count-files (.join node-path vault-root "eggs")
+                                                  #(contains? egg-extensions (string/lower-case (.extname node-path %))))
+                        :entities    (count-files (.join node-path nest "entities") md-file?)
+                        :concepts    (count-files (.join node-path nest "concepts") md-file?)
+                        :sources     (count-files (.join node-path nest "sources") md-file?)
+                        :lastHatchAt (metrics-at vault-root "hatch-metrics.json")
+                        :lastGroomAt (metrics-at vault-root "groom-metrics.json")}))))))
+
 (defn peck!
   "Runs the Peck workflow for `question` without filing the answer back.
   Resolves to {:answer :citedSlugs :candidateSlugs :steps}. `steps` is what

--- a/src/main/frontend/components/wiki_status.cljs
+++ b/src/main/frontend/components/wiki_status.cljs
@@ -26,6 +26,16 @@
       (p/then (fn [result] (reset! *recent-clucks (bean/->clj result))))
       (p/catch (fn [error] (reset! *recent-clucks {:error (str error)})))))
 
+(defn- fetch-coop-summary! [*summary]
+  (-> (ipc/ipc "wikiCoopSummary" (vault-root))
+      (p/then (fn [r] (reset! *summary (bean/->clj r))))
+      (p/catch (fn [_] (reset! *summary {})))))
+
+(defn- fetch-pending! [*pending]
+  (-> (ipc/ipc "wikiIngestPreview" (vault-root))
+      (p/then (fn [r] (reset! *pending (count (:pending (bean/->clj r))))))
+      (p/catch (fn [_] (reset! *pending nil)))))
+
 (defn- fetch-deep-last! [*deep-last]
   (-> (ipc/ipc "wikiGroomMetrics" (vault-root))
       (p/then (fn [m] (reset! *deep-last (:at (bean/->clj m)))))
@@ -115,6 +125,28 @@
        [:div.mt-2
         (ui/button {:variant :outline :size :sm :on-click #(open-report! (:reportPath report))} "Open report file")])]))
 
+;; The "Your coop" block at the top of Coop status — read-only counts + when
+;; things last ran. `summary` from wikiCoopSummary; `pending` a count or nil.
+(rum/defc coop-overview < rum/static
+  [summary pending]
+  (let [{:keys [eggs entities concepts sources lastHatchAt lastGroomAt]} summary
+        nest-total (+ (or entities 0) (or concepts 0) (or sources 0))]
+    [:div.mb-4
+     [:h3.text-lg.font-medium.mb-1 "Your coop"]
+     [:div.text-sm.opacity-80.space-y-0.5
+      [:div (str (or eggs 0) " source " (if (= 1 eggs) "file" "files") " in ")
+       [:code "eggs/"]
+       (when (and pending (pos? pending))
+         [:span " · "
+          [:a.underline {:on-click #(state/pub-event! [:modal/show-hatch])}
+           (str pending " not yet hatched — hatch now")]])]
+      [:div (str nest-total " nest " (if (= 1 nest-total) "page" "pages"))
+       (when (pos? nest-total)
+         (str " (" entities " entity, " concepts " concept, " sources " source)"))]
+      [:div.text-xs.opacity-60
+       "Last hatch: " (if lastHatchAt (telemetry/ago lastHatchAt) "never")
+       "  ·  Last groom: " (if lastGroomAt (telemetry/ago lastGroomAt) "never")]]]))
+
 (rum/defcs coop-status-modal < rum/reactive
   (rum/local nil ::recent-clucks)
   (rum/local nil ::groom-report)
@@ -123,9 +155,13 @@
   (rum/local nil ::deep-progress)
   (rum/local nil ::deep-poll-id)
   (rum/local nil ::deep-last)
+  (rum/local nil ::coop-summary)
+  (rum/local nil ::pending)
   {:will-mount (fn [state]
                  (fetch-recent-clucks! (get state ::recent-clucks))
                  (fetch-deep-last! (get state ::deep-last))
+                 (fetch-coop-summary! (get state ::coop-summary))
+                 (fetch-pending! (get state ::pending))
                  state)
    :will-unmount (fn [state]
                    (when-let [id @(get state ::deep-poll-id)] (js/clearInterval id))
@@ -140,6 +176,9 @@
         deep-prog @*deep-progress]
     [:div.w-full.mx-auto {:class "md:max-w-[600px]"}
      [:h2#modal-headline.text-xl.mb-3 "Coop status"]
+
+     (when-let [s @(get state ::coop-summary)]
+       (coop-overview s @(get state ::pending)))
 
      [:div.mb-4
       [:h3.text-lg.font-medium.mb-1 "Recent clucks"]


### PR DESCRIPTION
Closes #15.

The coop's folder model (`eggs/ nest/ clucks/ …`) was invisible from inside the app. **Coop status** now opens with a read-only block:

> **Your coop**
> N source files in `eggs/`  ( · M not yet hatched — *hatch now* )
> X nest pages (a entity, b concept, c source)
> Last hatch: 2h ago · Last groom: never

- `electron.wiki/coop-summary!` — eggs count, nest pages per subfolder, and the ms-epoch `at` from `hatch-metrics.json` / `groom-metrics.json`. All plain fs reads, no subprocess. `:wikiCoopSummary` IPC.
- `wiki_status.cljs`: fetches it (+ the pending count from `wikiIngestPreview`) on open; renders `coop-overview`; the "hatch now" link opens the Hatch modal.

Index-drift status was left out on purpose — it needs a groom run, and "Run groom" is right there in the same panel.

Verified: `coop-summary!` returns correct counts + timestamps for a populated fixture and `{}` for no graph; the block renders (all-zeros for an empty coop, screenshot in the issue thread). Both builds 0 warnings, clj-kondo clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)