### PR TITLE
Friendly LLM error messages in Peck, Hatch and Settings

### DIFF
--- a/src/main/frontend/components/chat.cljs
+++ b/src/main/frontend/components/chat.cljs
@@ -117,7 +117,7 @@
       [:div.inline-block.bg-gray-04.rounded.px-3.py-2.text-sm text]]
 
      :error
-     [:div.text-sm.text-red-500 (str "Error: " text)]
+     (llm-banner/error-view text)
 
      :learned
      [:div.text-sm.rounded.px-3.py-2 {:class "bg-gray-03 border-l-2 border-gray-11"}

--- a/src/main/frontend/components/ingest.cljs
+++ b/src/main/frontend/components/ingest.cljs
@@ -141,7 +141,7 @@
      (llm-banner/provider-banner)
 
      (when @*error
-       [:div.text-sm.text-red-500.my-2 (str "Error: " @*error)])
+       [:div.my-2 (llm-banner/error-view @*error)])
 
      (cond
        (and @*busy? (nil? preview))

--- a/src/main/frontend/components/llm_banner.cljs
+++ b/src/main/frontend/components/llm_banner.cljs
@@ -1,7 +1,7 @@
 (ns frontend.components.llm-banner
-  "A small non-blocking banner shown at the top of the Peck and Hatch panels
-  when no LLM provider is configured — Kip can't hatch or answer without one,
-  and before this the first call just errored. See frontend.handler.llm."
+  "Shared LLM-related UI bits: the 'no provider set' banner at the top of Peck
+  and Hatch, and a humanised error view (title + hint + collapsible raw). Both
+  lean on frontend.handler.llm."
   (:require [frontend.handler.llm :as llm-handler]
             [frontend.state :as state]
             [logseq.shui.ui :as ui]
@@ -23,3 +23,26 @@
        (ui/button {:size :sm :variant :outline
                    :on-click #(state/open-settings! :llm)}
                   "Set it up")])))
+
+;; Render an LLM failure humanely — a short title + a hint + a collapsible
+;; "Show details" with the raw error. `raw` is the original error string
+;; (a rejected IPC message, a `failed` entry's :error, stderr).
+(rum/defcs error-view
+  < (rum/local false ::open?)
+  [state raw]
+  (let [*open? (::open? state)
+        {:keys [title hint] :as parsed} (llm-handler/humanize-error raw)
+        raw-str (:raw parsed)]
+    [:div.text-sm.text-red-500
+     (if title
+       [:<>
+        [:div.font-medium title]
+        (when hint [:div.text-xs.opacity-80 hint])
+        [:button.text-xs.underline.opacity-60.mt-1
+         {:on-click #(swap! *open? not)}
+         (if @*open? "Hide details" "Show details")]
+        (when @*open?
+          [:pre.text-xs.opacity-70.mt-1.whitespace-pre-wrap
+           {:style {:max-height "8rem" :overflow-y "auto"}}
+           raw-str])]
+       raw-str)]))

--- a/src/main/frontend/components/llm_settings.cljs
+++ b/src/main/frontend/components/llm_settings.cljs
@@ -7,6 +7,7 @@
   directory."
   (:require [cljs-bean.core :as bean]
             [electron.ipc :as ipc]
+            [frontend.components.llm-banner :as llm-banner]
             [frontend.config :as config]
             [frontend.handler.llm :as llm-handler]
             [frontend.state :as state]
@@ -162,5 +163,6 @@
           [:div.text-sm.my-1 {:class (if (= type :success) "text-green-500" "text-red-500")} text])
 
         (when-let [{:keys [success error]} @*test-result]
-          [:div.text-sm.my-1 {:class (if success "text-green-500" "text-red-500")}
-           (if success "Connection OK." (str "Failed: " error))])])]))
+          (if success
+            [:div.text-sm.my-1.text-green-500 "Connection OK."]
+            [:div.my-1 (llm-banner/error-view error)]))])]))

--- a/src/main/frontend/handler/llm.cljs
+++ b/src/main/frontend/handler/llm.cljs
@@ -56,3 +56,45 @@
   []
   (let [{:keys [loaded? configured?]} (:kip/llm @state/state)]
     (and loaded? (not configured?))))
+
+(defn humanize-error
+  "Turn a raw LLM error (a string — a rejected IPC message, a `failed` entry's
+  :error, stderr) into {:title :hint :raw}. :title/:hint are nil when nothing
+  matched — callers fall back to showing :raw."
+  [raw]
+  (let [s (str raw)
+        m (condp #(re-find %1 %2) s
+            #"(?i)\((?:401|403)\)|unauthor|invalid.{0,12}api.?key|authentication.?fail|x-api-key"
+            {:title "The provider rejected your API key."
+             :hint  "Check the key in Settings → LLM (and that it matches the selected provider)."}
+
+            #"(?i)\(429\)|rate.?limit|too many requests|quota|insufficient_quota"
+            {:title "The provider is rate-limiting you."
+             :hint  "Wait a minute and try again — or check your plan's usage limits."}
+
+            #"(?i)ECONNREFUSED|fetch failed|ECONNRESET|socket hang up|network error"
+            {:title "Couldn't reach the LLM provider."
+             :hint  "Check your connection. For a local model, make sure the server is running (e.g. `ollama serve`)."}
+
+            #"(?i)ENOTFOUND|EAI_AGAIN|getaddrinfo"
+            {:title "Couldn't resolve the provider's address."
+             :hint  "Check the Base URL in Settings → LLM."}
+
+            #"(?i)ETIMEDOUT|TimeoutError|timed? ?out|request timeout"
+            {:title "The request timed out."
+             :hint  "The provider may be slow or overloaded — try again."}
+
+            #"(?i)_API_KEY is required|_MODEL is required|_BASE_URL is required|no model configured|no provider|provider .{0,10}not"
+            {:title "The LLM provider isn't fully set up."
+             :hint  "Fill in the missing field in Settings → LLM."}
+
+            #"(?i)\(404\)|model.{0,24}(not found|does not exist|no such|unknown|not available|invalid)|does not exist.{0,8}model"
+            {:title "That model isn't available for this provider."
+             :hint  "Pick a valid model in Settings → LLM."}
+
+            #"(?i)\(5\d\d\)|internal server error|service unavailable|overloaded|bad gateway"
+            {:title "The provider had a server error."
+             :hint  "Usually temporary — try again in a moment."}
+
+            nil)]
+    (assoc m :raw s)))

--- a/src/test/frontend/handler/llm_test.cljs
+++ b/src/test/frontend/handler/llm_test.cljs
@@ -55,3 +55,28 @@
 
 (deftest configured?-unknown-provider
   (is (false? (llm/configured? {:provider "kip" :providers {:kip {:apiKey "" :model ""}}}))))
+
+(deftest humanize-error-classification
+  (are [raw expected-title] (= expected-title (:title (llm/humanize-error raw)))
+    "api.deepseek.com request failed (401): Authentication Fails"  "The provider rejected your API key."
+    "invalid x-api-key"                                            "The provider rejected your API key."
+    "request failed (429): rate limit exceeded"                    "The provider is rate-limiting you."
+    "insufficient_quota"                                           "The provider is rate-limiting you."
+    "fetch failed"                                                 "Couldn't reach the LLM provider."
+    "connect ECONNREFUSED 127.0.0.1:11434"                         "Couldn't reach the LLM provider."
+    "getaddrinfo ENOTFOUND api.example"                            "Couldn't resolve the provider's address."
+    "ETIMEDOUT"                                                    "The request timed out."
+    "ANTHROPIC_API_KEY is required when PROVIDER=anthropic"        "The LLM provider isn't fully set up."
+    "OPENAI_MODEL is required when PROVIDER=openai"                "The LLM provider isn't fully set up."
+    "model gpt-9 does not exist or you do not have access"         "That model isn't available for this provider."
+    "request failed (503): service unavailable"                    "The provider had a server error."))
+
+(deftest humanize-error-unmatched-keeps-raw
+  (let [{:keys [title hint raw]} (llm/humanize-error "something weird\n  at stack")]
+    (is (nil? title))
+    (is (nil? hint))
+    (is (= "something weird\n  at stack" raw))))
+
+(deftest humanize-error-always-has-raw
+  (is (= "api.x request failed (401)" (:raw (llm/humanize-error "api.x request failed (401)"))))
+  (is (= "" (:raw (llm/humanize-error nil)))))


### PR DESCRIPTION
Closes #12.

A failed LLM call showed the raw string — a JSON blob or a stack trace. Now it's a short title + a hint, with **Show details** for the raw text:

> **The provider rejected your API key.**
> Check the key in Settings → LLM (and that it matches the selected provider).
> *Show details*

- **`frontend.handler.llm/humanize-error`** — classifies the raw error string into `{:title :hint :raw}`: 401/403, 429 / quota, `ECONNREFUSED` / `fetch failed`, `ENOTFOUND`, timeout, missing key/model/baseUrl, unknown model, 5xx. Unmatched errors fall through to `:raw`.
- **`llm-banner/error-view`** — the shared title + hint + collapsible raw `<pre>`.
- `chat.cljs` / `ingest.cljs` / `llm_settings.cljs` render it instead of `(str error)`.

This matches the strings the retrieval layer already emits — a structured `{code}` from `kip/scripts/lib/llm.js` could follow but isn't needed for the common cases.

**Testing:** `humanize-error` verified via REPL over every branch + 3 new deftests (suite **204 / 0**). The friendly view renders in Peck (screenshot in issue). Both builds 0 warnings, clj-kondo clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)