### PR TITLE
Welcome card on the first open of a coop

### DIFF
--- a/src/main/frontend/components/welcome.cljs
+++ b/src/main/frontend/components/welcome.cljs
@@ -1,0 +1,55 @@
+(ns frontend.components.welcome
+  "A one-time welcome card shown the first time a coop is opened. Three lines on
+  the farm metaphor, the Peck/Documents toggle, and a button into Settings →
+  LLM. Dismissal is permanent per coop (a localStorage flag), so this never
+  interrupts twice."
+  (:require [frontend.state :as state]
+            [frontend.storage :as storage]
+            [frontend.util :as util]
+            [rum.core :as rum]
+            [logseq.shui.ui :as ui]))
+
+(defn- seen-key []
+  (str "kip-welcome-seen-" (state/get-current-repo)))
+
+(defn seen? []
+  (boolean (storage/get (seen-key))))
+
+(defn mark-seen! []
+  (storage/set (seen-key) true))
+
+(def ^:private chick
+  "  \\\\\n  (o>\n\\_//)\n \\_/_)\n  _|_")
+
+(rum/defc welcome-card
+  [close-fn]
+  (let [done! (fn [] (mark-seen!) (close-fn))]
+    [:div.w-full.mx-auto {:class "md:max-w-[440px]"}
+     [:div.flex.flex-col.items-center.text-center
+      [:pre.font-mono.text-sm.mb-3
+       {:aria-hidden "true"
+        :style {:color "var(--ls-active-primary-color, #10b981)" :margin 0 :line-height 1.3}}
+       chick]
+      [:h2#modal-headline.text-xl.mb-2 "Welcome to Kip"]]
+     [:div.text-sm.opacity-80.space-y-2.my-3
+      [:p "Drop documents into " [:code "eggs/"] " and Kip hatches them into "
+       [:code "nest/"] " — a cross-linked wiki of entity, concept and source pages."]
+      [:p "Then " [:b "peck"] " it: ask a question and get an answer that cites the "
+       [:code "[[pages]]"] " it came from, or tell Kip a fact to file away."]
+      [:p "You're in Peck now. Press " [:kbd.px-1.border.rounded "Ctrl/⌘ + 1"]
+       " any time to switch to Documents and back."]]
+     [:div.flex.gap-2.justify-end.mt-4
+      (ui/button {:variant :ghost :size :sm :on-click done!} "Look around")
+      (ui/button {:size :sm
+                  :on-click (fn []
+                              (done!)
+                              (state/open-settings! :llm))}
+                 "Get started — set up an LLM →")]]))
+
+(defn maybe-show!
+  "Show the welcome card once per coop. Marks it seen as soon as it opens so a
+  reload mid-read doesn't bring it back."
+  []
+  (when (and (util/electron?) (state/get-current-repo) (not (seen?)))
+    (mark-seen!)
+    (state/set-modal! welcome-card {:center? true})))

--- a/src/main/frontend/handler/events.cljs
+++ b/src/main/frontend/handler/events.cljs
@@ -22,6 +22,7 @@
             [frontend.components.chat :as chat]
             [frontend.components.git :as git-component]
             [frontend.components.ingest :as ingest]
+            [frontend.components.welcome :as welcome]
             [frontend.components.plugins :as plugin]
             [frontend.components.shell :as shell]
             [frontend.components.whiteboard :as whiteboard]
@@ -408,7 +409,8 @@
           _ (js/setTimeout #(mobile/mobile-postinit) 1000)
           ;; FIXME: an ugly implementation for redirecting to page on new window is restored
           _ (repo-handler/graph-ready! repo)
-          _ (fs-watcher/load-graph-files! repo loaded-homepage-files)]))
+          _ (fs-watcher/load-graph-files! repo loaded-homepage-files)]
+    (welcome/maybe-show!)))
 
 (defmethod handle :notification/show [[_ {:keys [content status clear?]}]]
   (notification/show! content status clear?))


### PR DESCRIPTION
Closes #29.

A one-time dismissible modal shown the first time a coop is opened — the splash card was removed in the v0.2 onboarding pass, so first run currently drops you straight into Peck with no framing.

**Content:** the `eggs/` → `nest/` → peck metaphor in three sentences, the `Ctrl/⌘ + 1` Peck/Documents toggle, and a **Get started — set up an LLM** button that lands on Settings → LLM.

**Behaviour:** marked seen per coop (`kip-welcome-seen-<repo>` in localStorage) the instant it opens, so a reload mid-read doesn't reopen it. Fires from the `:graph/ready` handler; electron-only.

New: `frontend.components.welcome`. Touches `events.cljs` (`:graph/ready`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)