### PR TITLE
Paste text as a source

### DIFF
--- a/src/main/frontend/components/ingest.cljs
+++ b/src/main/frontend/components/ingest.cljs
@@ -15,6 +15,7 @@
             [electron.ipc :as ipc]
             [frontend.components.drop-source :as drop-source]
             [frontend.components.llm-banner :as llm-banner]
+            [frontend.components.paste-source :as paste-source]
             [frontend.components.telemetry :as telemetry]
             [frontend.config :as config]
             [frontend.handler.coop :as coop]
@@ -125,6 +126,7 @@
   (rum/local nil ::metrics)
   (rum/local false ::trace?)
   (rum/local false ::classic?)
+  (rum/local false ::paste?)
   {:will-mount   (fn [state]
                    (load-preview! (get state ::preview) (get state ::error) (get state ::busy?))
                    (llm-handler/refresh!)
@@ -142,6 +144,7 @@
         *metrics   (get state ::metrics)
         *trace?    (get state ::trace?)
         *classic?  (get state ::classic?)
+        *paste?    (get state ::paste?)
         ctx        {:*done *done :*remaining *remaining :*error *error :*busy? *busy?
                     :*progress *progress :*poll-id (get state ::poll-id)
                     :*metrics *metrics :*trace? *trace? :*classic? *classic?}
@@ -164,7 +167,17 @@
         (ui/button {:variant :outline :size :sm
                     :on-click #(pick-eggs! *preview *error *busy?)}
                    "Add source…")
+        (ui/button {:variant :outline :size :sm :class "ml-2"
+                    :on-click #(swap! *paste? not)}
+                   "Paste text…")
         [:span.text-xs.opacity-50.ml-2 "or drop a file here"]])
+
+     (when (and @*paste? (not @*busy?))
+       (paste-source/paste-panel
+        {:on-cancel #(reset! *paste? false)
+         :on-saved  (fn [_name]
+                      (reset! *paste? false)
+                      (load-preview! *preview *error *busy?))}))
 
      (llm-banner/provider-banner)
 

--- a/src/main/frontend/components/paste_source.cljs
+++ b/src/main/frontend/components/paste_source.cljs
@@ -1,0 +1,81 @@
+(ns frontend.components.paste-source
+  "Paste raw text — an article, notes, a transcript that isn't already a file —
+  and save it into <graph>/eggs/ as a Markdown source, hatchable like any other.
+  A title + textarea panel; writes eggs/<slug>.md with minimal YAML frontmatter
+  via the :wikiAddEgg IPC (electron.wiki/add-egg!)."
+  (:require [clojure.string :as string]
+            [electron.ipc :as ipc]
+            [frontend.config :as config]
+            [frontend.handler.coop :as coop]
+            [frontend.handler.notification :as notification]
+            [frontend.state :as state]
+            [promesa.core :as p]
+            [rum.core :as rum]
+            [logseq.shui.ui :as ui]))
+
+(defn- vault-root [] (config/get-repo-dir (state/get-current-repo)))
+
+(defn- slugify [s]
+  (-> (str s)
+      string/trim
+      string/lower-case
+      (string/replace #"['’]" "")
+      (string/replace #"[^a-z0-9]+" "-")
+      (string/replace #"^-+|-+$" "")
+      (as-> s (if (string/blank? s) "pasted-note" (subs s 0 (min 80 (count s)))))))
+
+(defn- egg-content [title body]
+  (str "---\n"
+       "title: " (string/replace (string/trim title) #"\n" " ") "\n"
+       "added: " (.toISOString (js/Date.)) "\n"
+       "source: pasted\n"
+       "---\n\n"
+       (string/trim body) "\n"))
+
+(defn- save! [*title *body *busy? {:keys [on-saved]}]
+  (let [title (string/trim @*title)
+        body  (string/trim @*body)]
+    (cond
+      (string/blank? body)  (notification/show! "Nothing to save — paste some text first." :warning true)
+      (string/blank? title) (notification/show! "Give it a title." :warning true)
+      :else
+      (do
+        (reset! *busy? true)
+        (-> (ipc/ipc "wikiAddEgg" (vault-root) (str (slugify title) ".md") (egg-content title body))
+            (p/then (fn [r]
+                      (let [{:keys [ok name duplicate reason]} (js->clj r :keywordize-keys true)]
+                        (cond
+                          (and ok duplicate)
+                          (notification/show! (str "That text is already in your coop as " duplicate ".") :info true)
+                          ok
+                          (do (notification/show! (str "Saved as eggs/" name ".") :success true)
+                              (coop/refresh-counts!)
+                              (reset! *title "") (reset! *body "")
+                              (when on-saved (on-saved name)))
+                          :else
+                          (notification/show! (str "Couldn't save: " (or reason "unknown error")) :error true)))))
+            (p/catch (fn [e] (notification/show! (str "Couldn't save: " e) :error true)))
+            (p/finally (fn [] (reset! *busy? false))))))))
+
+(rum/defcs paste-panel
+  < (rum/local "" ::title)
+    (rum/local "" ::body)
+    (rum/local false ::busy?)
+  [state {:keys [on-cancel] :as opts}]
+  (let [*title (::title state)
+        *body  (::body state)
+        *busy? (::busy? state)]
+    [:div.my-2.p-3.rounded.border.border-gray-06.bg-gray-02
+     [:input.form-input.is-small.w-full.mb-2
+      {:type "text" :placeholder "Title — e.g. \"Acme call notes\""
+       :value @*title
+       :on-change #(reset! *title (.. % -target -value))}]
+     [:textarea.form-textarea.is-small.w-full
+      {:rows 8 :placeholder "Paste article text, notes, a transcript…"
+       :value @*body
+       :on-change #(reset! *body (.. % -target -value))}]
+     [:div.flex.gap-2.justify-end.mt-2
+      (ui/button {:variant :ghost :size :sm :on-click #(when on-cancel (on-cancel))} "Cancel")
+      (ui/button {:size :sm :disabled @*busy?
+                  :on-click #(save! *title *body *busy? opts)}
+                 (if @*busy? "Saving…" "Save to eggs/"))]]))


### PR DESCRIPTION
Closes #30.

Adds a **Paste text…** button next to *Add source…* in the Hatch modal. It opens an inline panel — a title field and a textarea — and Save writes `eggs/<slug>.md` with minimal YAML frontmatter:

```
---
title: Acme call notes
added: 2026-08-28T…Z
source: pasted
---

<your text>
```

Goes through the existing `:wikiAddEgg` IPC, so byte-identical text is deduped and reported, and the Hatch preview refreshes on save — the new egg is hatchable immediately.

For article text, meeting notes, transcripts that aren't already a file on disk.

New: `frontend.components.paste-source`. Touches `ingest.cljs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)