### PR TITLE
Tooltips + a legend for the farm-metaphor folder names

### DIFF
--- a/src/main/frontend/components/coop_glossary.cljs
+++ b/src/main/frontend/components/coop_glossary.cljs
@@ -1,0 +1,32 @@
+(ns frontend.components.coop-glossary
+  "One place for the farm-metaphor folder names and their plain-language
+  glosses. `term` renders a `<code>` with a hover tooltip; `legend` is the
+  one-liner shown in the help panel and the coop-map."
+  (:require [clojure.string :as string]))
+
+(def glosses
+  "Folder name (no slash, no dot) → what it actually is."
+  {"eggs"     "your source documents — drop files here"
+   "nest"     "the cross-linked wiki Kip builds from them"
+   "clucks"   "Kip's activity log"
+   "roost"    "the search index — disposable, rebuilt any time"
+   "henhouse" "LLM provider and skills config"})
+
+(defn- key-for [label]
+  (-> (str label) string/lower-case (string/replace #"[^a-z]" "")))
+
+(defn term
+  "A `<code>` tag for a metaphor folder name with its gloss as a tooltip.
+  `(term \"eggs/\")` or `(term \"eggs\" \"the eggs folder\")`."
+  ([label] (term label label))
+  ([k label]
+   (let [g (get glosses (key-for k))]
+     [:code (cond-> {} g (assoc :title g)) label])))
+
+(defn legend
+  "eggs = … · nest = … · clucks = … — for the help panel and coop-map."
+  []
+  [:div.text-xs.opacity-60.leading-relaxed
+   (->> ["eggs" "nest" "clucks" "roost" "henhouse"]
+        (map (fn [k] (str k " = " (get glosses k))))
+        (string/join "  ·  "))])

--- a/src/main/frontend/components/drop_source.cljs
+++ b/src/main/frontend/components/drop_source.cljs
@@ -7,6 +7,7 @@
   (:require [cljs-bean.core :as bean]
             [clojure.string :as string]
             [electron.ipc :as ipc]
+            [frontend.components.coop-glossary :as glossary]
             [frontend.config :as config]
             [frontend.handler.coop :as coop]
             [frontend.handler.notification :as notification]
@@ -32,7 +33,7 @@
 (defn- notify-added! [name]
   (notification/show!
    [:div.text-sm
-    [:div "Added " [:b name] " to " [:code "eggs/"] "."]
+    [:div "Added " [:b name] " to " (glossary/term "eggs/") "."]
     [:button.text-xs.underline.opacity-80.hover:opacity-100.mt-1
      {:on-click (fn []
                   (notification/clear-all!)

--- a/src/main/frontend/components/ingest.cljs
+++ b/src/main/frontend/components/ingest.cljs
@@ -13,6 +13,7 @@
   (:require [cljs-bean.core :as bean]
             [clojure.string :as string]
             [electron.ipc :as ipc]
+            [frontend.components.coop-glossary :as glossary]
             [frontend.components.drop-source :as drop-source]
             [frontend.components.llm-banner :as llm-banner]
             [frontend.components.telemetry :as telemetry]
@@ -155,7 +156,7 @@
      [:div.w-full.mx-auto {:class "md:max-w-[600px]"}
       [:h2#modal-headline.text-xl.mb-3 "Hatch sources"]
      [:p.text-sm.opacity-70.mb-3
-      "Turns new or changed files in " [:code "eggs/"] ", " [:code "journals/"] " and "
+      "Turns new or changed files in " (glossary/term "eggs/") ", " [:code "journals/"] " and "
       [:code "pages/"] " into nest pages — no per-file review. Runs in batches of "
       (str batch-size) "."]
 

--- a/src/main/frontend/components/llm_settings.cljs
+++ b/src/main/frontend/components/llm_settings.cljs
@@ -7,6 +7,7 @@
   directory."
   (:require [cljs-bean.core :as bean]
             [electron.ipc :as ipc]
+            [frontend.components.coop-glossary :as glossary]
             [frontend.components.llm-banner :as llm-banner]
             [frontend.config :as config]
             [frontend.handler.llm :as llm-handler]
@@ -191,7 +192,7 @@
         [:div.text-xs.opacity-50.my-3
          "Stored in plaintext at .henhouse/llm.json inside your graph folder "
          "— a local-machine-only secret, not encrypted at rest. Add "
-         [:code ".henhouse/"] " to your graph's ignore list if it's under version control."]
+         (glossary/term "henhouse" ".henhouse/") " to your graph's ignore list if it's under version control."]
 
         [:div.flex.gap-2.items-center.my-2
          (ui/button

--- a/src/main/frontend/components/onboarding.cljs
+++ b/src/main/frontend/components/onboarding.cljs
@@ -1,6 +1,7 @@
 (ns frontend.components.onboarding
   (:require [rum.core :as rum]
             [frontend.state :as state]
+            [frontend.components.coop-glossary :as glossary]
             [frontend.components.onboarding.setups :as setups]))
 
 (rum/defc intro
@@ -26,7 +27,7 @@
 
    [:p.mt-4.mb-1 [:b "How it fits together"]]
    [:ul.text-sm.opacity-80
-    [:li [:b "Hatch"] " — a file you drop in " [:code "eggs/"] " becomes linked "
+    [:li [:b "Hatch"] " — a file you drop in " (glossary/term "eggs/") " becomes linked "
      [:code "entity"] " / " [:code "concept"] " / " [:code "source"] " pages under The Nest."]
     [:li [:b "Peck"] " — ask the nest a question (answers cite " [:code "[[pages]]"]
      "), or tell it a fact or an upcoming meeting."]
@@ -34,11 +35,11 @@
 
    [:p.mt-4.mb-1 [:b "The coop"]]
    [:ul.text-sm.opacity-80
-    [:li [:code "eggs/"] " — the source documents you add"]
-    [:li [:code "nest/"] " — the LLM-maintained wiki"]
-    [:li [:code "clucks/"] " — the activity log"]
-    [:li [:code ".henhouse/"] " — LLM provider + skills config"]
-    [:li [:code ".roost/"] " — the search index (disposable — rebuild any time)"]]
+    [:li (glossary/term "eggs/") " — the source documents you add"]
+    [:li (glossary/term "nest/") " — the LLM-maintained wiki"]
+    [:li (glossary/term "clucks/") " — the activity log"]
+    [:li (glossary/term "henhouse" ".henhouse/") " — LLM provider + skills config"]
+    [:li (glossary/term "roost" ".roost/") " — the search index (disposable — rebuild any time)"]]
 
    [:p.mt-4.mb-1 [:b "Feedback"]]
    [:ul

--- a/src/main/frontend/components/skills_settings.cljs
+++ b/src/main/frontend/components/skills_settings.cljs
@@ -6,8 +6,8 @@
   skills.js has no native deps). Everything lives in
   <graph>/.henhouse/skills.json, so every call passes the open graph's directory."
   (:require [cljs-bean.core :as bean]
-            [clojure.string :as string]
             [electron.ipc :as ipc]
+            [frontend.components.coop-glossary :as glossary]
             [frontend.config :as config]
             [frontend.state :as state]
             [frontend.ui :as ui]
@@ -93,7 +93,7 @@
         [:h2.text-lg.font-medium.mt-1.mb-2 "Skills"]
         [:div.text-xs.opacity-60.mb-3
          "Small programs Peck can run while answering a question. Toggle one off to "
-         "stop offering it. Config lives in " [:code ".henhouse/skills.json"] "."]
+         "stop offering it. Config lives in " (glossary/term "henhouse" ".henhouse/skills.json") "."]
 
         [:div.mb-6
          (for [{:keys [name description source enabled]} @*skills]

--- a/src/main/frontend/components/wiki_status.cljs
+++ b/src/main/frontend/components/wiki_status.cljs
@@ -10,6 +10,7 @@
   (:require [cljs-bean.core :as bean]
             [clojure.string :as string]
             [electron.ipc :as ipc]
+            [frontend.components.coop-glossary :as glossary]
             [frontend.components.telemetry :as telemetry]
             [frontend.config :as config]
             [frontend.state :as state]
@@ -135,17 +136,20 @@
      [:h3.text-lg.font-medium.mb-1 "Your coop"]
      [:div.text-sm.opacity-80.space-y-0.5
       [:div (str (or eggs 0) " source " (if (= 1 eggs) "file" "files") " in ")
-       [:code "eggs/"]
+       (glossary/term "eggs/")
        (when (and pending (pos? pending))
          [:span " · "
           [:a.underline {:on-click #(state/pub-event! [:modal/show-hatch])}
            (str pending " not yet hatched — hatch now")]])]
-      [:div (str nest-total " nest " (if (= 1 nest-total) "page" "pages"))
+      [:div (str nest-total " ")
+       (glossary/term "nest" "nest")
+       (str " " (if (= 1 nest-total) "page" "pages"))
        (when (pos? nest-total)
          (str " (" entities " entity, " concepts " concept, " sources " source)"))]
       [:div.text-xs.opacity-60
        "Last hatch: " (if lastHatchAt (telemetry/ago lastHatchAt) "never")
-       "  ·  Last groom: " (if lastGroomAt (telemetry/ago lastGroomAt) "never")]]]))
+       "  ·  Last groom: " (if lastGroomAt (telemetry/ago lastGroomAt) "never")]]
+     [:div.mt-2 (glossary/legend)]]))
 
 (rum/defcs coop-status-modal < rum/reactive
   (rum/local nil ::recent-clucks)


### PR DESCRIPTION
Closes #31.

Keep the metaphor, lower its cost.

New `frontend.components.coop-glossary` holds one map — `eggs` / `nest` / `clucks` / `roost` / `henhouse` → a plain-language gloss — plus:
- `term` — renders `<code>` with the gloss as a `title` tooltip
- `legend` — the `eggs = … · nest = … · …` one-liner

**Tooltips** now cover every metaphor folder name in the UI: the drop-source notification, the Hatch modal, LLM settings, Skills settings, and the help panel's "The coop" list.

**Legend** appears under the "Your coop" block in Coop status. The help panel's existing "The coop" list already reads as its legend.

Also drops a stale unused `clojure.string` require from `skills_settings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)