### PR TITLE
Citations peek in the sidebar instead of switching to Documents

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -501,10 +501,21 @@
 (declare page-reference)
 
 (defn open-page-ref
-  [e page-name redirect-page-name page-name-in-block contents-page? whiteboard-page?]
+  ([e page-name redirect-page-name page-name-in-block contents-page? whiteboard-page?]
+   (open-page-ref e page-name redirect-page-name page-name-in-block contents-page? whiteboard-page? nil))
+  ([e page-name redirect-page-name page-name-in-block contents-page? whiteboard-page? config]
   (util/stop e)
   (when (not (util/right-click? e))
     (cond
+      ;; Citations in a Peck answer peek in the right sidebar so the
+      ;; conversation stays put; cmd/ctrl-click opens the page in Documents.
+      (and (:page-ref-as-sidebar? config) (not (util/meta-key? e)))
+      (when-let [page-entity (db/entity [:block/name redirect-page-name])]
+        (state/sidebar-add-block!
+         (state/get-current-repo)
+         (:db/id page-entity)
+         :page))
+
       (gobj/get e "shiftKey")
       (when-let [page-entity (db/entity [:block/name redirect-page-name])]
         (state/sidebar-add-block!
@@ -528,7 +539,7 @@
   (when (and contents-page?
              (util/mobile?)
              (state/get-left-sidebar-open?))
-    (ui-handler/close-left-sidebar!)))
+    (ui-handler/close-left-sidebar!))))
 
 (rum/defc page-inner
   "The inner div of page reference component
@@ -561,10 +572,10 @@
                                                          (date/journal-title->custom-format page-name))
                                                     redirect-page-name)
                              redirect-page-name (string/lower-case redirect-page-name)]
-                         (open-page-ref e page-name redirect-page-name page-name-in-block contents-page? whiteboard-page?))
+                         (open-page-ref e page-name redirect-page-name page-name-in-block contents-page? whiteboard-page? config))
                        (set-mouse-down! false)))
       :on-key-up (fn [e] (when (and e (= (.-key e) "Enter"))
-                           (open-page-ref e page-name redirect-page-name page-name-in-block contents-page? whiteboard-page?)))}
+                           (open-page-ref e page-name redirect-page-name page-name-in-block contents-page? whiteboard-page? config)))}
 
      (if (and (coll? children) (seq children))
        (for [child children]

--- a/src/main/frontend/components/chat.cljs
+++ b/src/main/frontend/components/chat.cljs
@@ -114,6 +114,11 @@
       (str "⚙ " skill "  " (/ (js/Math.round (/ (or ms 0) 100)) 10) "s"
            (when-not ok "  — failed"))])])
 
+;; Citations in an answer open the page as a right-sidebar peek instead of
+;; switching the whole app to Documents — the conversation stays in view.
+;; cmd/ctrl-click still opens it in Documents.
+(def ^:private citation-config {:page-ref-as-sidebar? true})
+
 (rum/defc message-cp
   [{:keys [role text pages steps]}]
   [:div.py-2
@@ -128,10 +133,10 @@
      :learned
      [:div.text-sm.rounded.px-3.py-2 {:class "bg-gray-03 border-l-2 border-gray-11"}
       [:div.text-xs.font-medium.opacity-60.mb-1 "✓ Learned"]
-      [:div.prose.prose-sm.max-w-none (block/inline-text {} :markdown text)]
+      [:div.prose.prose-sm.max-w-none (block/inline-text citation-config :markdown text)]
       (when (seq pages)
         [:div.text-xs.opacity-70.mt-1
-         (block/inline-text {} :markdown
+         (block/inline-text citation-config :markdown
                             (string/join "  ·  "
                                          (for [{:keys [action slug]} pages]
                                            (str (if (= action "create") "created" "updated") " [[" slug "]]"))))])]
@@ -140,7 +145,7 @@
      ;; via the app's own markdown renderer, given a plain unsaved string.
      [:div
       (when (seq steps) (steps-line steps))
-      [:div.prose.prose-sm.max-w-none (block/inline-text {} :markdown text)]])])
+      [:div.prose.prose-sm.max-w-none (block/inline-text citation-config :markdown text)]])])
 
 (defn- first-run-showing? [llm counts]
   (and (not (first-run/dismissed?))


### PR DESCRIPTION
Closes #4.

Clicking a `[[page]]` citation in a Peck answer used to `redirect-to-page!` — flipping the whole app to Documents mode and dropping you out of the conversation.

Now, **in Peck answers only**, a plain click opens the page as a right-sidebar **peek** and the conversation stays exactly where it was. **cmd/ctrl-click** opens it in Documents for when you do want to edit.

Implementation:
- `open-page-ref` gains an optional `config` arg; with `{:page-ref-as-sidebar? true}` and no meta key it routes to `state/sidebar-add-block!` — the same peek path shift-click already uses throughout the app
- `chat.cljs` passes that config to `block/inline-text` for assistant answers and the "learned" page list

Page links everywhere else are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)