### PR TITLE
Hatch: review each source before writing

### DIFF
--- a/src/electron/electron/handler.cljs
+++ b/src/electron/electron/handler.cljs
@@ -546,6 +546,12 @@
 (defmethod handle :wikiIngestBatch [_ [_ vault-root limit trace? classic?]]
   (wiki/hatch-batch! vault-root limit trace? classic?))
 
+(defmethod handle :wikiIngestProposeNext [_ [_ vault-root limit skip classic?]]
+  (wiki/hatch-propose-next! vault-root limit skip classic?))
+
+(defmethod handle :wikiIngestCommitNext [_ [_ vault-root keep-slugs]]
+  (wiki/hatch-commit-next! vault-root keep-slugs))
+
 (defmethod handle :wikiIngestProgress [_ [_ vault-root]]
   (wiki/hatch-progress! vault-root))
 

--- a/src/electron/electron/wiki.cljs
+++ b/src/electron/electron/wiki.cljs
@@ -154,6 +154,27 @@
                       trace? (conj "--trace")
                       classic? (conj "--classic"))))
 
+(defn hatch-propose-next!
+  "\"Review before writing\": propose pages for the next pending source (past
+  `skip` in the current batch of `limit`) without writing anything. Resolves
+  to {:done true} when there's nothing left, otherwise {:source :relPath :kind
+  :remaining :plan [{:slug :title :type :action :summary}]} (or {:whiteboard
+  true} for a board — no plan to pick from). The full plan is stashed at
+  <coop>/.roost/hatch-plan.json for hatch-commit-next!."
+  [vault-root limit skip classic?]
+  (run-node-script! (script "hatch-all.js") vault-root
+                    (cond-> ["--propose-next" "--limit" (str limit) "--skip" (str skip)]
+                      classic? (conj "--classic"))))
+
+(defn hatch-commit-next!
+  "Commit the plan stashed by hatch-propose-next!, keeping only the pages whose
+  slug is in `keep-slugs` (a vector; nil = keep all). Resolves to {:source
+  :results [...] :skipped [...]} / {:source :keptNone true} / {:source :error}."
+  [vault-root keep-slugs]
+  (run-node-script! (script "hatch-all.js") vault-root
+                    (cond-> ["--commit-next"]
+                      (some? keep-slugs) (conj "--keep" (js/JSON.stringify (clj->js keep-slugs))))))
+
 (defn hatch-progress!
   "Reads <coop>/.roost/hatch-progress.json, written continuously by
   hatch-all.js during a batch. Resolves to {:done :total :current :running

--- a/src/main/frontend/components/ingest.cljs
+++ b/src/main/frontend/components/ingest.cljs
@@ -91,6 +91,59 @@
                    (stop-poll! *progress *poll-id)
                    (reset! *busy? false)))))
 
+;; --- "Review before writing" mode ----------------------------------------
+;; One file at a time: propose its pages (LLM), let the user keep/skip each,
+;; then commit. hatch-all.js --propose-next / --commit-next; the plan is
+;; stashed in .roost/hatch-plan.json between the two. `skip` steps past files
+;; that failed to propose (a committed file just drops out of the pending
+;; scan, so it usually stays 0).
+
+(declare review-next!)
+
+(defn- review-record! [*done proposal res]
+  (let [{:keys [source results error keptNone skipped]} res]
+    (swap! *done (fn [d]
+                   (cond
+                     error   (update d :failed conj {:source source :error error})
+                     keptNone d
+                     :else   (update d :hatched conj {:source source :kind (:kind proposal)
+                                                      :results results :skipped (or skipped [])}))))))
+
+(defn- review-commit! [{:keys [*rp *done] :as ctx} keep-all?]
+  (let [{:keys [proposal keeps]} @*rp
+        keep-slugs (when-not keep-all?
+                     (vec (filter keeps (map :slug (:plan proposal)))))]
+    (swap! *rp assoc :phase :committing)
+    (-> (ipc/ipc "wikiIngestCommitNext" (vault-root)
+                 (when-not keep-all? (clj->js (or keep-slugs []))))
+        (p/then (fn [r]
+                  (review-record! *done proposal (bean/->clj r))
+                  (coop/refresh-counts!)))
+        (p/catch (fn [e]
+                   (swap! *done update :failed conj {:source (:source proposal) :error (str e)})))
+        (p/finally (fn [] (review-next! ctx))))))
+
+(defn- review-next! [{:keys [*rp *classic? *preview *error *busy?] :as ctx}]
+  (swap! *rp assoc :phase :proposing :proposal nil :error nil)
+  (-> (ipc/ipc "wikiIngestProposeNext" (vault-root) batch-size (get @*rp :skip 0) (boolean @*classic?))
+      (p/then (fn [r]
+                (let [{:keys [done whiteboard plan] :as res} (bean/->clj r)]
+                  (cond
+                    done       (do (swap! *rp assoc :phase :done)
+                                   (load-preview! *preview *error *busy?))
+                    whiteboard (do (swap! *rp assoc :proposal res) (review-commit! ctx true))
+                    :else      (swap! *rp assoc
+                                      :phase :reviewing
+                                      :proposal res
+                                      :keeps (set (map :slug plan)))))))
+      (p/catch (fn [e]
+                 (swap! *rp assoc :phase :reviewing :proposal nil :error (str e))))))
+
+(defn- review-start! [ctx]
+  (reset! (:*done ctx) {:hatched [] :failed []})
+  (reset! (:*rp ctx) {:skip 0})
+  (review-next! ctx))
+
 (defn- per-file
   "The {:source :ms :ok} rows perf-report wants, from the modal's done state."
   [done]
@@ -115,6 +168,58 @@
    [:input {:type "checkbox" :checked checked? :on-change on-change}]
    label])
 
+(rum/defc review-panel
+  "The per-file plan review shown while ::rp is active. `rp` is its state map."
+  [rp {:keys [*rp] :as ctx}]
+  (let [{:keys [phase proposal keeps error]} rp
+        {:keys [source relPath plan remaining]} proposal]
+    [:div.my-2
+     (case phase
+       :proposing  [:div.text-sm.opacity-70 "Proposing pages for " [:span.font-medium (or source "the next file")] "…"]
+       :committing [:div.text-sm.opacity-70 "Writing…"]
+       :reviewing
+       [:div
+        (if error
+          [:div
+           [:div.my-1 (llm-banner/error-view error)]
+           [:div.flex.gap-2.mt-2
+            (ui/button {:variant :outline :size :sm
+                        :on-click #(do (swap! *rp update :skip inc) (review-next! ctx))}
+                       "Skip this file →")
+            (ui/button {:variant :ghost :size :sm :on-click #(reset! *rp {:skip 0 :phase :done})}
+                       "Stop review")]]
+          [:div
+           [:div.text-sm.mb-1
+            [:span.font-medium source]
+            (when relPath [:span.text-xs.opacity-50.ml-1 (str "(" relPath ")")])
+            (when (and (number? remaining) (pos? remaining))
+              [:span.text-xs.opacity-50.ml-1 (str "· " remaining " more after this")])]
+           (if (empty? plan)
+             [:div.text-sm.opacity-70.my-2 "No pages proposed for this file."]
+             [:ul.my-1
+              (for [{:keys [slug title type action summary]} plan]
+                [:li.text-sm.py-1 {:key slug}
+                 [:label.flex.items-start.gap-2.cursor-pointer
+                  [:input.mt-1 {:type "checkbox"
+                                :checked (boolean (keeps slug))
+                                :on-change #(swap! *rp update :keeps
+                                                   (fn [ks] ((if (keeps slug) disj conj) (or ks #{}) slug)))}]
+                  [:span
+                   [:span.font-medium title]
+                   [:span.text-xs.opacity-50.ml-1 (str "[" type " · " action "]")]
+                   (when-not (string/blank? summary)
+                     [:div.text-xs.opacity-60 summary])]]])])
+           [:div.flex.gap-2.mt-2
+            (ui/button {:size :sm :disabled (or (empty? plan) (empty? keeps))
+                        :on-click #(review-commit! ctx false)}
+                       (str "Write " (count keeps) (if (= 1 (count keeps)) " page" " pages") " →"))
+            (ui/button {:variant :outline :size :sm
+                        :on-click #(do (swap! *rp assoc :keeps #{}) (review-commit! ctx false))}
+                       "Skip this file")
+            (ui/button {:variant :ghost :size :sm :on-click #(reset! *rp {:skip 0 :phase :done})}
+                       "Stop")]])]
+       nil)]))
+
 (rum/defcs hatch-modal
   < rum/reactive
   (rum/local nil ::preview)
@@ -128,6 +233,8 @@
   (rum/local false ::trace?)
   (rum/local false ::classic?)
   (rum/local false ::paste?)
+  (rum/local false ::review?)
+  (rum/local nil ::rp)
   {:will-mount   (fn [state]
                    (load-preview! (get state ::preview) (get state ::error) (get state ::busy?))
                    (llm-handler/refresh!)
@@ -146,12 +253,16 @@
         *trace?    (get state ::trace?)
         *classic?  (get state ::classic?)
         *paste?    (get state ::paste?)
-        ctx        {:*done *done :*remaining *remaining :*error *error :*busy? *busy?
+        *review?   (get state ::review?)
+        *rp        (get state ::rp)
+        ctx        {:*preview *preview :*done *done :*remaining *remaining :*error *error :*busy? *busy?
                     :*progress *progress :*poll-id (get state ::poll-id)
-                    :*metrics *metrics :*trace? *trace? :*classic? *classic?}
+                    :*metrics *metrics :*trace? *trace? :*classic? *classic? :*rp *rp}
         preview    @*preview
         done       @*done
         remaining  @*remaining
+        rp         @*rp
+        reviewing? (and rp (not= :done (:phase rp)))
         started?   (or (seq (:hatched done)) (seq (:failed done)) (some? remaining))
         pending-n  (if started? (or remaining 0) (count (:pending preview)))]
     (drop-source/drop-zone
@@ -186,6 +297,9 @@
        [:div.my-2 (llm-banner/error-view @*error)])
 
      (cond
+       reviewing?
+       (review-panel rp ctx)
+
        (and @*busy? (nil? preview))
        [:div.text-sm.opacity-60.my-2 "Scanning sources…"]
 
@@ -244,14 +358,17 @@
               [:ul.list-disc.pl-5.mt-1 {:class "max-h-40 overflow-y-auto"}
                (for [[i {:keys [source kind kb]}] (map-indexed vector (:pending preview))]
                  [:li.text-xs.opacity-70 {:key i} (str "[" kind "] " source " (" kb " KB)")])]])
+           (checkbox-row "Review each source's pages before writing" @*review? #(swap! *review? not))
            (checkbox-row "Record LLM activity (thinking + timings)" @*trace? #(swap! *trace? not))
            (checkbox-row "Classic mode — one LLM call per page (slower; for comparison)" @*classic? #(swap! *classic? not))
            (ui/button
-            {:on-click #(run-batch! ctx)
+            {:on-click #(if @*review? (review-start! ctx) (run-batch! ctx))
              :disabled @*busy?}
-            (str (if started? "Hatch next " "Start — hatch ")
-                 (min batch-size pending-n)
-                 (when started? (str " (" pending-n " left)"))))])
+            (if @*review?
+              (str "Review " (min batch-size pending-n) " file" (when (not= 1 (min batch-size pending-n)) "s") " →")
+              (str (if started? "Hatch next " "Start — hatch ")
+                   (min batch-size pending-n)
+                   (when started? (str " (" pending-n " left)")))))])
 
         (when (and (not @*busy?) @*metrics)
           [:details.mt-3.text-sm


### PR DESCRIPTION
Closes #41. Pairs with **JWE24-code/kip#4** (the `--propose-next` / `--commit-next` CLI) — merge that first, it ships in `static/scripts` via gulp's syncScripts.

A **"Review each source's pages before writing"** checkbox in the Hatch modal. When on, the button becomes **"Review N files →"** and walks the pending sources one at a time:

1. propose its pages — one LLM call, nothing written
2. show each proposed page with a keep/skip checkbox, its `[type · action]`, and a one-line summary
3. **"Write N pages →"** commits only the checked ones
4. on to the next file

**"Skip this file"** writes nothing but marks it handled (won't re-propose); **"Stop"** ends the walk. Whiteboards auto-commit (nothing to pick). Results fold into the same Hatched / Failed lists a batch run produces.

New: `:wikiIngestProposeNext` / `:wikiIngestCommitNext` IPC → `electron.wiki/hatch-propose-next!` / `hatch-commit-next!`. `ingest.cljs` gains a small review-loop (`::rp` state) + a `review-panel` component. Batch mode is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)