### PR TITLE
Schedule the deep groom from Settings

### DIFF
--- a/src/electron/electron/core.cljs
+++ b/src/electron/electron/core.cljs
@@ -20,6 +20,7 @@
             [electron.state :as state]
             [electron.git :as git]
             [electron.reminders :as reminders]
+            [electron.groom-scheduler :as groom-scheduler]
             [electron.window :as win]
             [electron.exceptions :as exceptions]
             ["/electron/utils" :as js-utils]
@@ -297,6 +298,8 @@
                (git/configure-auto-commit!)
 
                (reminders/start-scheduler!)
+
+               (groom-scheduler/start-scheduler!)
 
                (vreset! *setup-fn
                         (fn []

--- a/src/electron/electron/groom_scheduler.cljs
+++ b/src/electron/electron/groom_scheduler.cljs
@@ -1,0 +1,107 @@
+(ns electron.groom-scheduler
+  "Runs the deep groom (scripts/groom.js --deep) on a weekly schedule the user
+  sets in Settings — a day of the week and a time. Like electron.reminders it's
+  a plain setInterval in the main process: nothing fires while Kip is closed,
+  but the next tick after launch runs a slot that came due meanwhile (\"as soon
+  as possible after\").
+
+  Config (electron.configs, global — the schedule isn't per-graph):
+    :groom/schedule  {:enabled bool :day 0..6 (Sun..Sat) :time \"HH:MM\"}
+    :groom/last-run  epoch ms of the last run we started"
+  (:require ["electron" :refer [Notification]]
+            [electron.configs :as cfgs]
+            [electron.logger :as logger]
+            [electron.state :as state]
+            [electron.utils :as utils]
+            [electron.wiki :as wiki]
+            [promesa.core :as p]))
+
+(def ^:private log-error (partial logger/error "[GroomSchedule]"))
+
+(defonce ^:private *interval (atom nil))
+(defonce ^:private *running? (atom false))
+
+(def ^:private week-ms (* 7 24 60 60 1000))
+
+(defn- parse-hhmm [s]
+  (when-let [[_ h m] (re-matches #"(\d{1,2}):(\d{2})" (str s))]
+    (let [h (js/parseInt h 10) m (js/parseInt m 10)]
+      (when (and (<= 0 h 23) (<= 0 m 59)) [h m]))))
+
+(defn- prev-occurrence
+  "Epoch ms of the most recent `day`@`time` at or before `now`, or nil if the
+  schedule is malformed."
+  [day time-str now]
+  (when-let [[h m] (parse-hhmm time-str)]
+    (let [d (js/Date. now)
+          _ (.setHours d h m 0 0)
+          diff (mod (- (.getDay d) day) 7)        ; days to step back to `day`
+          cand (- (.getTime d) (* diff 24 60 60 1000))]
+      (if (<= cand now) cand (- cand (* 7 24 60 60 1000))))))
+
+(defn next-occurrence [day time-str now]
+  (some-> (prev-occurrence day time-str now) (+ week-ms)))
+
+(defn- fire! []
+  (reset! *running? true)
+  (cfgs/set-item! :groom/last-run (js/Date.now))
+  (let [graphs (filter string? (state/get-all-graph-paths))]
+    (logger/info "[GroomSchedule]" (str "deep groom for " (count graphs) " graph(s)"))
+    (-> (p/all (for [g graphs]
+                 (-> (wiki/groom-deep! g)
+                     (p/catch (fn [err] (log-error (str "deep groom failed for " g ": " err)) nil)))))
+        (p/finally
+          (fn [_]
+            (reset! *running? false)
+            (utils/send-to-renderer "notification"
+                                    {:type "info"
+                                     :payload "Scheduled deep groom finished — see Coop status."})
+            (when (and Notification (.-isSupported Notification))
+              (.show (Notification. #js {:title "Kip — deep groom"
+                                         :body "The scheduled deep groom finished. Open Coop status for the report."
+                                         :silent true}))))))))
+
+(defn- tick! []
+  (let [{:keys [enabled day time]} (some-> (cfgs/get-item :groom/schedule)
+                                           (js->clj :keywordize-keys true))]
+    (when (and enabled (not @*running?) (number? day) time)
+      (when-let [prev (prev-occurrence day time (js/Date.now))]
+        (when (> prev (or (cfgs/get-item :groom/last-run) 0))
+          (fire!))))))
+
+(defn schedule-info
+  "The renderer's view: current schedule + last/next run (epoch ms or nil)."
+  []
+  (let [{:keys [enabled day time] :as sched} (some-> (cfgs/get-item :groom/schedule)
+                                                     (js->clj :keywordize-keys true))]
+    #js {:enabled (boolean enabled)
+         :day     (if (number? day) day 3)          ; default Wednesday
+         :time    (or time "03:00")
+         :lastRun (or (cfgs/get-item :groom/last-run) nil)
+         :nextRun (when (and enabled (number? day) time)
+                    (next-occurrence day time (js/Date.now)))
+         :configured (some? sched)}))
+
+(defn set-schedule!
+  "Persist a schedule from the renderer. Marks now as the last run when the
+  schedule is first turned on, so an already-passed slot this week doesn't
+  fire immediately."
+  [{:strs [enabled day time]}]
+  (let [enabled (boolean enabled)
+        day (if (number? day) (int day) 3)
+        time (or (and (parse-hhmm time) time) "03:00")
+        was (cfgs/get-item :groom/schedule)]
+    (cfgs/set-item! :groom/schedule {:enabled enabled :day day :time time})
+    (when (and enabled (not (:enabled (some-> was (js->clj :keywordize-keys true)))))
+      (cfgs/set-item! :groom/last-run (js/Date.now)))
+    (schedule-info)))
+
+(defn start-scheduler! []
+  (when @*interval (js/clearInterval @*interval))
+  (js/setTimeout tick! 8000)
+  (reset! *interval (js/setInterval tick! 60000))
+  (logger/info "[GroomSchedule]" "scheduler started (60s)"))
+
+(defn stop-scheduler! []
+  (when @*interval (js/clearInterval @*interval))
+  (reset! *interval nil))

--- a/src/electron/electron/handler.cljs
+++ b/src/electron/electron/handler.cljs
@@ -29,6 +29,7 @@
             [electron.shell :as shell]
             [electron.state :as state]
             [electron.update :as update]
+            [electron.groom-scheduler :as groom-scheduler]
             [electron.utils :as utils]
             [electron.wiki :as wiki]
             [electron.window :as win]
@@ -572,6 +573,12 @@
 
 (defmethod handle :checkForAppUpdate [_ [_ force?]]
   (update/check! {:force? (boolean force?)}))
+
+(defmethod handle :getGroomSchedule [_ _]
+  (groom-scheduler/schedule-info))
+
+(defmethod handle :setGroomSchedule [_ [_ sched]]
+  (groom-scheduler/set-schedule! (js->clj sched)))
 
 (defmethod handle :wikiChat [_ [_ vault-root question trace?]]
   (wiki/peck! vault-root question (boolean trace?)))

--- a/src/main/frontend/components/groom_settings.cljs
+++ b/src/main/frontend/components/groom_settings.cljs
@@ -1,0 +1,72 @@
+(ns frontend.components.groom-settings
+  "The 'schedule the deep groom' control (Settings → Features). Backed by the
+  :getGroomSchedule / :setGroomSchedule IPC (electron.groom-scheduler, main
+  process). The schedule is global, not per-graph."
+  (:require [cljs-bean.core :as bean]
+            [electron.ipc :as ipc]
+            [frontend.util :as util]
+            [promesa.core :as p]
+            [rum.core :as rum]))
+
+(def ^:private days ["Sunday" "Monday" "Tuesday" "Wednesday" "Thursday" "Friday" "Saturday"])
+
+(defn- load! [*state]
+  (-> (ipc/ipc "getGroomSchedule")
+      (p/then (fn [r] (reset! *state (bean/->clj r))))
+      (p/catch (fn [_] nil))))
+
+(defn- save! [*state patch]
+  (let [{:keys [enabled day time]} (merge @*state patch)]
+    (swap! *state merge patch)
+    (-> (ipc/ipc "setGroomSchedule" (clj->js {:enabled enabled :day day :time time}))
+        (p/then (fn [r] (reset! *state (bean/->clj r))))
+        (p/catch (fn [_] nil)))))
+
+(defn- when-str [ms]
+  (when (number? ms)
+    (try (.toLocaleString (js/Date. ms) js/undefined
+                          #js {:weekday "short" :month "short" :day "numeric"
+                               :hour "2-digit" :minute "2-digit"})
+         (catch :default _ nil))))
+
+(rum/defcs schedule-row
+  < rum/reactive
+    (rum/local nil ::s)
+    {:will-mount (fn [state] (load! (::s state)) state)}
+  [state]
+  (let [*s (::s state)
+        {:keys [enabled day time lastRun nextRun]} @*s]
+    (when @*s
+      [:div.it.my-2
+       [:label.flex.items-center.gap-2.text-sm.opacity-80.my-1.cursor-pointer
+        [:input {:type "checkbox" :checked (boolean enabled)
+                 :on-change #(save! *s {:enabled (not enabled)})}]
+        "Run the deep groom on a schedule"]
+       (when enabled
+         [:div.ml-6.mt-1.flex.flex-wrap.items-center.gap-2.text-sm
+          [:span.opacity-70 "Every"]
+          [:select.form-select.is-small
+           {:value (str (or day 3))
+            :on-change #(save! *s {:day (js/parseInt (util/evalue %) 10)})}
+           (for [[i d] (map-indexed vector days)]
+             [:option {:key i :value i} d])]
+          [:span.opacity-70 "at"]
+          [:input.form-input.is-small {:type "time" :value (or time "03:00")
+                                       :style {:width "7rem"}
+                                       :on-change #(save! *s {:time (util/evalue %)})}]])
+       (when enabled
+         [:div.ml-6.text-xs.opacity-60.mt-1
+          "Next: " (or (when-str nextRun) "—")
+          (when lastRun (str "  ·  last run " (when-str lastRun)))
+          ". Runs on the next launch if Kip was closed at that time."])])))
+
+(rum/defcs next-run-note
+  < rum/reactive
+    (rum/local nil ::s)
+    {:will-mount (fn [state] (load! (::s state)) state)}
+  [state]
+  (let [{:keys [enabled nextRun lastRun]} @(::s state)]
+    (when enabled
+      [:div.text-xs.opacity-60
+       "Scheduled deep groom — next " (or (when-str nextRun) "—")
+       (when lastRun (str ", last " (when-str lastRun)))])))

--- a/src/main/frontend/components/settings.cljs
+++ b/src/main/frontend/components/settings.cljs
@@ -5,6 +5,7 @@
             [frontend.colors :as colors]
             [frontend.components.assets :as assets]
             [frontend.components.conversion :as conversion-component]
+            [frontend.components.groom-settings :as groom-settings]
             [frontend.components.llm-settings :as llm-settings]
             [frontend.components.skills-settings :as skills-settings]
             [frontend.components.plugins :as plugins]
@@ -707,7 +708,9 @@
      (when (util/electron?)
        (http-server-switcher-row))
      (flashcards-switcher-row enable-flashcards?)
-     (zotero-settings-row)]))
+     (zotero-settings-row)
+     (when (util/electron?)
+       (groom-settings/schedule-row))]))
 
 
 (def DEFAULT-ACTIVE-TAB-STATE [:general :general])

--- a/src/main/frontend/components/wiki_status.cljs
+++ b/src/main/frontend/components/wiki_status.cljs
@@ -11,6 +11,7 @@
             [clojure.string :as string]
             [electron.ipc :as ipc]
             [frontend.components.coop-glossary :as glossary]
+            [frontend.components.groom-settings :as groom-settings]
             [frontend.components.telemetry :as telemetry]
             [frontend.config :as config]
             [frontend.state :as state]
@@ -213,6 +214,9 @@
        (if-let [at @(get state ::deep-last)]
          (str "Last deep groom " (telemetry/ago at))
          "No deep groom recorded yet")]
+
+      (when (util/electron?)
+        [:div.mb-2 (groom-settings/next-run-note)])
 
       (cond
         @*deep-loading?


### PR DESCRIPTION
Closes #45.

**Settings → Features** gets a checkbox + day-of-week + time to run the deep groom weekly.

`electron.groom-scheduler` is a 60s main-process tick, same shape as `electron.reminders` — nothing fires while Kip is closed, but the first tick after launch runs a slot that came due meanwhile ("as soon as possible after").

- `:getGroomSchedule` / `:setGroomSchedule` IPC → `electron.groom-scheduler`; global config `:groom/schedule` `{:enabled :day :time}` + `:groom/last-run` in `configs.edn`
- `frontend.components.groom-settings` — the control + a "next / last run" note reused under the Deep-groom button in Coop status
- on fire: `groom.js --deep` for each open graph, then an OS notification pointing at Coop status
- turning the schedule on stamps "now" as the last run, so an already-passed slot this week doesn't fire immediately

Not part of v0.2.2 (re-triaged P3) — separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)