### PR TITLE
build: pack resources/app into app.asar (#48)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -190,8 +190,10 @@ jobs:
         continue-on-error: true
         run: |
           mkdir -p /tmp/coop/.roost
+          # scripts/ is unpacked out of app.asar (see packaging/linux/build.sh)
           ELECTRON_RUN_AS_NODE=1 KIP_COOP_ROOT=/tmp/coop \
-            app/out/Kip-linux-x64/kip app/out/Kip-linux-x64/resources/app/scripts/reminders.js list --json
+            app/out/Kip-linux-x64/kip \
+            app/out/Kip-linux-x64/resources/app.asar.unpacked/scripts/reminders.js list --json
 
       - uses: actions/upload-artifact@v4
         with:
@@ -215,7 +217,7 @@ jobs:
           notes+=$'| Platform | File |\n|---|---|\n'
           notes+=$'| Windows 10/11 x64 | `Kip-*-windows-x64.zip` — extract, run `Kip.exe` |\n'
           notes+=$'| Linux x64 | `Kip-*-linux-x64.tar.gz` — `tar -xzf`, run `./kip` |\n\n'
-          notes+=$'Windows SmartScreen: the binary is unsigned — *More info → Run anyway*.\n'
+          notes+=$'Windows SmartScreen: the binary is signed but the certificate is self-issued, so SmartScreen still shows *unknown publisher* — *More info → Run anyway*.\n'
           notes+=$'Linux/Wayland: `./kip --ozone-platform-hint=auto`.\n\n'
           # This release's section, lifted from the app changelog.
           section=$(awk -v v="$ver" '

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,9 @@ De-Logseq'd the first-run experience and a batch of polish.
   `.henhouse/skills/` runs with your privileges, so Settings → Skills now
   asks you to approve it (showing what it declares) before Peck can use it.
 - Leaner package — dropped the non-English Electron locales (~12 MB).
+- **Faster unzip and launch** — the app is now packed into a single
+  `app.asar` instead of ~15k loose files; the retrieval layer (`scripts/`)
+  and the native SQLite addon stay unpacked so Hatch/Peck/Groom still work.
 
 ## [0.2.1] — 2026-08-28
 

--- a/packaging/linux/PKGBUILD
+++ b/packaging/linux/PKGBUILD
@@ -39,8 +39,6 @@ package() {
   sed -i 's|/opt/kip|/opt/kip|' "$pkgdir/usr/bin/kip"
 
   install -Dm644 "$_repo/app/packaging/linux/kip.desktop" "$pkgdir/usr/share/applications/kip.desktop"
-  install -Dm644 "$pkgdir/opt/kip/resources/app/icon.png" \
-                 "$pkgdir/usr/share/icons/hicolor/512x512/apps/kip.png" 2>/dev/null || \
-  install -Dm644 "$pkgdir/opt/kip/resources/app/icons/logseq.png" \
+  install -Dm644 "$pkgdir/opt/kip/resources/icon.png" \
                  "$pkgdir/usr/share/icons/hicolor/512x512/apps/kip.png"
 }

--- a/packaging/linux/README.md
+++ b/packaging/linux/README.md
@@ -65,10 +65,10 @@ open.
 
 ```bash
 ELECTRON_RUN_AS_NODE=1 KIP_COOP_ROOT=/path/to/a/graph \
-  ~/.local/opt/kip/kip ~/.local/opt/kip/resources/app/scripts/hatch-all.js --preview
+  ~/.local/opt/kip/kip ~/.local/opt/kip/resources/app.asar.unpacked/scripts/hatch-all.js --preview
 ```
 
 Then launch the GUI and exercise Peck / Hatch sources / Deep groom / LLM
-settings — those all shell out to `resources/app/scripts/` and were the parts
+settings — those all shell out to `resources/app.asar.unpacked/scripts/` and were the parts
 that broke on Linux before the path-separator fix (`electron.wiki` /
 `electron.llm` / `electron.skills` now use `path.join`, not `\\`).

--- a/packaging/linux/build.sh
+++ b/packaging/linux/build.sh
@@ -143,8 +143,11 @@ node -e "const p='$APP/package.json',j=require(p);j.version='$VERSION';require('
 cp -f "$APP/icon.png" "$OUT/resources/icon.png" 2>/dev/null || true
 
 step "pack app.asar"
-# @electron/asar ships as a transitive dep of @electron-forge/cli (static devDep)
-"$APP_DIR/static/node_modules/.bin/asar" pack "$APP" "$OUT/resources/app.asar" \
+# @electron/asar ships as a transitive dep of @electron-forge/cli (static
+# devDep). Run its bin JS through node — the .bin/ shim isn't reliably linked
+# for transitive deps (present on Linux, missing on Windows).
+ASAR_JS="$(cd "$APP_DIR/static" && node -e 'process.stdout.write(require.resolve("@electron/asar/bin/asar.js"))')"
+node "$ASAR_JS" pack "$APP" "$OUT/resources/app.asar" \
   --unpack-dir "{scripts,node_modules/better-sqlite3}" \
   --unpack "*.node"
 rm -rf "$APP"

--- a/packaging/linux/build.sh
+++ b/packaging/linux/build.sh
@@ -134,6 +134,21 @@ fi
 VERSION="$(grep -oE '[0-9]+\.[0-9]+\.[0-9]+' "$APP_DIR/src/main/frontend/version.cljs" | head -1)"
 node -e "const p='$APP/package.json',j=require(p);j.version='$VERSION';require('fs').writeFileSync(p,JSON.stringify(j,null,2)+'\n')"
 
+# --- 7. pack resources/app -> app.asar ----------------------------------------
+# One archive instead of ~15k loose files: faster to unzip, faster to load.
+# scripts/ stays unpacked (electron.wiki spawns `node scripts/*.js` by path —
+# can't cwd into or exec out of an asar) and so do native .node addons
+# (better-sqlite3). asar auto-creates app.asar.unpacked/ for the --unpack* set.
+# the Linux installer / PKGBUILD need a real icon file — keep one outside the asar
+cp -f "$APP/icon.png" "$OUT/resources/icon.png" 2>/dev/null || true
+
+step "pack app.asar"
+# @electron/asar ships as a transitive dep of @electron-forge/cli (static devDep)
+"$APP_DIR/static/node_modules/.bin/asar" pack "$APP" "$OUT/resources/app.asar" \
+  --unpack-dir "{scripts,node_modules/better-sqlite3}" \
+  --unpack "*.node"
+rm -rf "$APP"
+
 step "done — $OUT  (Kip $VERSION, cljs:$CLJS_MODE)"
 echo "run:      $OUT/kip"
 echo "install:  bash $here/install.sh"

--- a/packaging/linux/install.sh
+++ b/packaging/linux/install.sh
@@ -40,9 +40,8 @@ install -m755 "$here/kip.sh" "$BIN"
 
 echo "==> $ICON"
 mkdir -p "$(dirname "$ICON")"
-# static/icon.png is 512x512; fall back to the app icon in resources
-cp -f "$KIP_HOME/resources/app/icon.png" "$ICON" 2>/dev/null \
-  || cp -f "$KIP_HOME/resources/app/icons/logseq.png" "$ICON"
+# build.sh stages a 512x512 icon.png next to app.asar for exactly this
+cp -f "$KIP_HOME/resources/icon.png" "$ICON" 2>/dev/null || true
 
 echo "==> $DESKTOP"
 mkdir -p "$(dirname "$DESKTOP")"

--- a/packaging/windows/build.ps1
+++ b/packaging/windows/build.ps1
@@ -139,7 +139,19 @@ $j = Get-Content $pkg -Raw | ConvertFrom-Json
 $j.version = $VERSION
 ($j | ConvertTo-Json -Depth 20) + "`n" | Set-Content $pkg -NoNewline
 
-# --- 7. Authenticode sign (optional) --------------------------------------
+# --- 7. pack resources\app -> app.asar -----------------------------------
+# One archive instead of ~15k loose files: faster to unzip, faster to load.
+# scripts\ stays unpacked (electron.wiki spawns `node scripts\*.js` by path —
+# can't cwd into or exec out of an asar) and so do native .node addons
+# (better-sqlite3). asar auto-creates app.asar.unpacked\ for the --unpack* set.
+Step 'pack app.asar'
+# @electron/asar ships as a transitive dep of @electron-forge/cli (static devDep)
+& "$APP_DIR\static\node_modules\.bin\asar.cmd" pack "$APP" "$OUT\resources\app.asar" `
+  --unpack-dir "{scripts,node_modules/better-sqlite3}" --unpack "*.node"
+if ($LASTEXITCODE) { throw 'asar pack failed' }
+Remove-Item "$APP" -Recurse -Force
+
+# --- 8. Authenticode sign (optional) --------------------------------------
 # Set KIP_SIGN_CMD to a signing command; each target path is appended to it.
 # e.g. Azure Trusted Signing:
 #   KIP_SIGN_CMD='signtool sign /v /fd SHA256 /tr http://timestamp.acs.microsoft.com /td SHA256 /dlib "C:\...\Azure.CodeSigning.Dlib.dll" /dmdf "C:\...\metadata.json"'

--- a/packaging/windows/build.ps1
+++ b/packaging/windows/build.ps1
@@ -145,8 +145,13 @@ $j.version = $VERSION
 # can't cwd into or exec out of an asar) and so do native .node addons
 # (better-sqlite3). asar auto-creates app.asar.unpacked\ for the --unpack* set.
 Step 'pack app.asar'
-# @electron/asar ships as a transitive dep of @electron-forge/cli (static devDep)
-& "$APP_DIR\static\node_modules\.bin\asar.cmd" pack "$APP" "$OUT\resources\app.asar" `
+# @electron/asar ships as a transitive dep of @electron-forge/cli (static
+# devDep). Run its bin JS through node — the .bin\ shim isn't reliably linked
+# for transitive deps (present on Linux, missing on Windows).
+Push-Location "$APP_DIR\static"
+$ASAR_JS = (node -e 'process.stdout.write(require.resolve("@electron/asar/bin/asar.js"))')
+Pop-Location
+node "$ASAR_JS" pack "$APP" "$OUT\resources\app.asar" `
   --unpack-dir "{scripts,node_modules/better-sqlite3}" --unpack "*.node"
 if ($LASTEXITCODE) { throw 'asar pack failed' }
 Remove-Item "$APP" -Recurse -Force

--- a/src/electron/electron/wiki.cljs
+++ b/src/electron/electron/wiki.cljs
@@ -35,9 +35,14 @@
 
 ;; scripts/ ships inside the app: gulp syncs ../scripts (source + a pure-JS
 ;; node_modules; better-sqlite3 comes from the app's own Electron-ABI copy)
-;; into static/scripts, which is app.getAppPath()/scripts both in dev (static/)
-;; and packaged (resources/app/).
-(def scripts-dir (.join node-path (.getAppPath app) "scripts"))
+;; into static/scripts. In dev that's app.getAppPath()/scripts (static/scripts).
+;; A packaged build asar-packs resources/app but keeps scripts/ unpacked (we
+;; spawn `node scripts/*.js` by path — you can't cwd into or exec out of an
+;; asar), so there it lives at resources/app.asar.unpacked/scripts.
+(def scripts-dir
+  (if ^boolean (.-isPackaged app)
+    (.join node-path js/process.resourcesPath "app.asar.unpacked" "scripts")
+    (.join node-path (.getAppPath app) "scripts")))
 
 (defn- script
   "Absolute path to a bundled coop-maintenance script, e.g. (script \"groom.js\").


### PR DESCRIPTION
Closes #48 (the asar half — node_modules prune split to a follow-up).

## What

Package the app as a single `app.asar` instead of ~15k loose files. Faster to unzip after a download, faster for Electron to load.

`scripts/` (the retrieval layer), `better-sqlite3`, and every `*.node` addon stay **unpacked** in `app.asar.unpacked/` — `electron.wiki` spawns `node scripts/*.js` by path, and you can't `cwd` into or `exec` out of an asar.

## Changes

- **`electron.wiki/scripts-dir`** — resolves to `resourcesPath/app.asar.unpacked/scripts` when `app.isPackaged`, else `getAppPath()/scripts` (dev, unchanged). `electron.llm` + `electron.skills` `js/require` through this constant, so they follow automatically.
- **`packaging/linux/build.sh` + `packaging/windows/build.ps1`** — asar pack step right after the version write (`--unpack-dir "{scripts,node_modules/better-sqlite3}" --unpack "*.node"`); stage a real `icon.png` next to `app.asar` for the Linux installer.
- **`install.sh` / `PKGBUILD` / `packaging/linux/README.md`** — icon + retrieval-layer script paths.
- **`.github/workflows/build.yml`** — smoke-test path → `app.asar.unpacked/scripts/reminders.js`; fixed the stale "binary is unsigned" line in the generated release notes (it's signed now, just self-issued).
- **`CHANGELOG.md`** — "faster unzip and launch" under `[0.2.2]`.

## Verification

- `clojure -M:cljs release electron --debug` — clean, 0 warnings.
- Isolated pack test (real `static/` after gulp + compile): `app.asar` + `app.asar.unpacked/{scripts,node_modules/better-sqlite3}` produced correctly; `hatch-all.js`, `reminders.js`, and `better_sqlite3.node` all land unpacked. `*.node` also correctly catches `@logseq/rsapi` and `electron-deeplink`.
- Full packaged GUI smoke test: **relies on CI** (local Electron dist download is broken on this machine, unrelated to this change).

## Not in scope

`node_modules` prune — `dugite` (140 MB, git backend; `electron.git` still compiles even though #27 removed the git UI) and the `electron-builder`/`electron-forge` tooling hoisted to top-level `node_modules` (~400 MB). Separate follow-up so it gets its own packaged test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)