### PR TITLE
fix: don't run Hatch/Peck/Groom against the in-memory graph (#51)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,9 @@ De-Logseq'd the first-run experience and a batch of polish.
 - **Trimmed the "…" menu** — dropped the leftover Logseq entries (plugins,
   themes, export graph, import) and the redundant Peck entry.
 - Opening Hatch with no folder open now explains itself instead of
-  erroring.
+  erroring — and Hatch / Peck / Groom now refuse to run against the
+  in-memory demo graph (or a graph whose folder has gone missing)
+  instead of failing deep in a script with a cryptic path error.
 - **Windows builds are code-signed** (self-signed for now) — the binary
   carries a publisher identity; SmartScreen still warns until there's a
   real certificate.

--- a/src/electron/electron/wiki.cljs
+++ b/src/electron/electron/wiki.cljs
@@ -66,13 +66,28 @@
                         (js/Object.assign base #js {"KIP_COOP_ROOT" vault-root})
                         base))))
 
+(defn- coop-dir?
+  "vault-root is usable as a KIP_COOP_ROOT: nil (scripts fall back to their
+  bundled ./coop) or a string naming an existing directory. The in-memory demo
+  graph reports its dir as \"memory:///local\" — that must never reach a script,
+  since path.resolve turns it into a bogus \"memory:/local\" and the run dies on
+  mkdir (issue #51)."
+  [vault-root]
+  (or (nil? vault-root)
+      (and (string? vault-root)
+           (try (.isDirectory (fs/statSync vault-root))
+                (catch :default _ false)))))
+
 (defn- run-node-script!
   "Spawns the bundled Electron-as-Node against <script-path> <args...> (cwd =
   scripts-dir, no shell — args go through as an argv array), collects stdout,
   and resolves a promise with the parsed JSON result on a clean exit, or
-  rejects with stderr (or the parse error) otherwise."
+  rejects with stderr (or the parse error) otherwise. Rejects up front when
+  vault-root isn't a real folder — see coop-dir?."
   [script-path vault-root args]
-  (let [deferred (p/deferred)
+  (if-not (coop-dir? vault-root)
+    (p/rejected (js/Error. "Open a folder first (File → Open a folder) — Kip can only hatch, peck and groom a folder-backed graph."))
+   (let [deferred (p/deferred)
         job (child-process/spawn (.-execPath js/process)
                                  (apply array script-path args)
                                  #js {:cwd scripts-dir :env (script-env vault-root)})
@@ -98,7 +113,7 @@
                  (p/reject! deferred (if (string/blank? stderr)
                                        (str script-path " exited with code " code)
                                        stderr)))))))
-    deferred))
+    deferred)))
 
 (defn recent-clucks! [vault-root]
   (run-node-script! (script "recent-clucks.js") vault-root []))
@@ -255,7 +270,7 @@
   (p/create
    (fn [resolve* _reject]
      (try
-       (if (or (string/blank? vault-root) (string/blank? filename))
+       (if (or (string/blank? vault-root) (string/blank? filename) (not (coop-dir? vault-root)))
          (resolve* #js {:ok false :reason "no-graph"})
          (resolve* (clj->js (write-egg-content (.join node-path vault-root "eggs")
                                                (.basename node-path filename)

--- a/src/main/frontend/components/ingest.cljs
+++ b/src/main/frontend/components/ingest.cljs
@@ -89,27 +89,33 @@
                     (when (and err (nil? @*error)) (reset! *error err))))))
       (p/catch (fn [_] (when from-error (reset! *recovery {})))))) ;; no progress file — still flag it
 
+(def ^:private no-graph-msg
+  "Open a folder first (File → Open a folder) — Kip hatches the sources inside a graph's folder.")
+
 (defn- run-batch! [{:keys [*preview *done *remaining *error *busy? *progress *poll-id *metrics *trace? *classic? *recovery]}]
-  (reset! *busy? true)
-  (reset! *error nil)
-  (reset! *recovery nil)
-  (reset! *progress nil)
-  (start-poll! *progress *poll-id)
-  (-> (ipc/ipc "wikiIngestBatch" (vault-root) batch-size (boolean @*trace?) (boolean @*classic?))
-      (p/then (fn [r]
-                (let [{:keys [hatched failed remaining metrics]} (bean/->clj r)]
-                  (swap! *done (fn [d] {:hatched (into (:hatched d) hatched)
-                                        :failed  (into (:failed d) failed)}))
-                  (reset! *remaining remaining)
-                  (reset! *metrics metrics)
-                  (coop/refresh-counts!))))
-      (p/catch (fn [e]
-                 (reset! *error (str e))
-                 (check-recovery! *recovery *error (str e))
-                 (load-preview! *preview *error *busy?)))
-      (p/finally (fn []
-                   (stop-poll! *progress *poll-id)
-                   (reset! *busy? false)))))
+  (if (config/demo-graph?)
+    (reset! *error no-graph-msg)
+    (do
+      (reset! *busy? true)
+      (reset! *error nil)
+      (reset! *recovery nil)
+      (reset! *progress nil)
+      (start-poll! *progress *poll-id)
+      (-> (ipc/ipc "wikiIngestBatch" (vault-root) batch-size (boolean @*trace?) (boolean @*classic?))
+          (p/then (fn [r]
+                    (let [{:keys [hatched failed remaining metrics]} (bean/->clj r)]
+                      (swap! *done (fn [d] {:hatched (into (:hatched d) hatched)
+                                            :failed  (into (:failed d) failed)}))
+                      (reset! *remaining remaining)
+                      (reset! *metrics metrics)
+                      (coop/refresh-counts!))))
+          (p/catch (fn [e]
+                     (reset! *error (str e))
+                     (check-recovery! *recovery *error (str e))
+                     (load-preview! *preview *error *busy?)))
+          (p/finally (fn []
+                       (stop-poll! *progress *poll-id)
+                       (reset! *busy? false)))))))
 
 ;; --- "Review before writing" mode ----------------------------------------
 ;; One file at a time: propose its pages (LLM), let the user keep/skip each,
@@ -160,9 +166,12 @@
                  (swap! *rp assoc :phase :reviewing :proposal nil :error (str e))))))
 
 (defn- review-start! [ctx]
-  (reset! (:*done ctx) {:hatched [] :failed []})
-  (reset! (:*rp ctx) {:skip 0})
-  (review-next! ctx))
+  (if (config/demo-graph?)
+    (reset! (:*error ctx) no-graph-msg)
+    (do
+      (reset! (:*done ctx) {:hatched [] :failed []})
+      (reset! (:*rp ctx) {:skip 0})
+      (review-next! ctx))))
 
 (defn- per-file
   "The {:source :ms :ok} rows perf-report wants, from the modal's done state."


### PR DESCRIPTION
Closes #51.

## Bug

From a user's `main.log` (Windows):
```
[Coop] hatch-all.js exited with code 1:
ENOENT: mkdir '...\scripts\memory:\local\.roost'
```
The open folder (`New folder`) was deleted while Kip was running; Kip fell back to the `local` in-memory graph, whose directory is `"memory:///local"`. That reached the script as `KIP_COOP_ROOT`, `path.resolve` turned it into a bogus relative `memory:/local`, and `openDb` died on `mkdir`.

## Fix

- **`electron.wiki/run-node-script!`** — new `coop-dir?` check: `vault-root` must be `nil` (scripts use their bundled `./coop`) or a string naming an existing directory. Otherwise reject immediately with *"Open a folder first…"*. Covers Hatch, Peck, Groom, recent-log. `add-egg!` gets the same check → `{:ok false :reason "no-graph"}`.
- **`ingest.cljs`** — `run-batch!` / `review-start!` bail with a plain message when `config/demo-graph?` is true at click time. The render already hides the button for the demo graph, but that state can go stale if the graph switches under an open modal (which is how the user hit this).

## Verification

- `app` + `electron` compile: clean, 0 warnings.
- `clojure -M:test compile test` → **204 tests / 1719 assertions, 0 failures**.
- Lint: no new warnings in the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)