### PR TITLE
fix: retrieval layer can't load better-sqlite3 from the asar

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -209,13 +209,13 @@ jobs:
 
       - name: Smoke test (linux — the bundled retrieval layer runs under Electron-as-Node)
         if: runner.os == 'Linux' && env.KIP_TARGET != 'installer'
-        continue-on-error: true
         run: |
-          mkdir -p /tmp/coop/.roost
-          # scripts/ is unpacked out of app.asar (see packaging/linux/build.sh)
-          ELECTRON_RUN_AS_NODE=1 KIP_COOP_ROOT=/tmp/coop \
-            app/out/Kip-linux-x64/kip \
-            app/out/Kip-linux-x64/resources/app.asar.unpacked/scripts/reminders.js list --json
+          mkdir -p /tmp/coop/{eggs,.roost}
+          S=app/out/Kip-linux-x64/resources/app.asar.unpacked/scripts
+          # reminders.js is pure JS; hatch-all.js --preview opens the SQLite DB
+          # (better-sqlite3 -> bindings) — the part that actually broke.
+          ELECTRON_RUN_AS_NODE=1 KIP_COOP_ROOT=/tmp/coop app/out/Kip-linux-x64/kip "$S/reminders.js" list --json
+          ELECTRON_RUN_AS_NODE=1 KIP_COOP_ROOT=/tmp/coop app/out/Kip-linux-x64/kip "$S/hatch-all.js" --preview
 
       - name: Smoke test (windows — the app launches and stays up)
         if: runner.os == 'Windows' && env.KIP_TARGET != 'installer'
@@ -267,12 +267,15 @@ jobs:
           R=squashfs-root/resources
           # extraResources must have landed the retrieval layer + its nested
           # node_modules (electron-builder prunes those from the asar)
-          test -f "$R/app.asar.unpacked/scripts/lib/skills.js"   || { echo "::error::scripts/ missing"; exit 1; }
-          test -d "$R/app.asar.unpacked/scripts/node_modules/gray-matter" || { echo "::error::scripts/node_modules pruned"; exit 1; }
-          # the retrieval layer runs under Electron-as-Node
-          mkdir -p /tmp/coop/.roost
-          ELECTRON_RUN_AS_NODE=1 KIP_COOP_ROOT=/tmp/coop \
-            ./squashfs-root/kip "$R/app.asar.unpacked/scripts/reminders.js" list --json
+          S="$R/app.asar.unpacked/scripts"
+          test -f "$S/lib/skills.js"                      || { echo "::error::scripts/ missing"; exit 1; }
+          test -d "$S/node_modules/gray-matter"           || { echo "::error::scripts/node_modules pruned"; exit 1; }
+          test -f "$S/node_modules/better-sqlite3/build/Release/better_sqlite3.node" || { echo "::error::better-sqlite3 not vendored"; exit 1; }
+          # the retrieval layer runs under Electron-as-Node — reminders.js is
+          # pure JS; hatch-all.js --preview opens the SQLite DB (the broken bit)
+          mkdir -p /tmp/coop/{eggs,.roost}
+          ELECTRON_RUN_AS_NODE=1 KIP_COOP_ROOT=/tmp/coop ./squashfs-root/kip "$S/reminders.js" list --json
+          ELECTRON_RUN_AS_NODE=1 KIP_COOP_ROOT=/tmp/coop ./squashfs-root/kip "$S/hatch-all.js" --preview
           # full launch — the main process loads electron.skills / electron.llm
           xvfb-run -a ./squashfs-root/kip --no-sandbox &
           pid=$!
@@ -303,6 +306,15 @@ jobs:
           }
           Write-Host "Kip.exe (installed) still running after 20s — ok"
           Stop-Process -Id $p.Id -Force -ErrorAction SilentlyContinue
+          # exercise the retrieval layer's SQLite path (better-sqlite3 -> bindings)
+          $root = Split-Path $exe
+          $S = Join-Path $root 'resources\app.asar.unpacked\scripts'
+          $env:ELECTRON_RUN_AS_NODE = '1'
+          $env:KIP_COOP_ROOT = Join-Path $env:RUNNER_TEMP 'coop'
+          New-Item -ItemType Directory -Force (Join-Path $env:KIP_COOP_ROOT 'eggs') | Out-Null
+          & $exe (Join-Path $S 'hatch-all.js') --preview
+          if ($LASTEXITCODE) { throw "hatch-all.js --preview failed (exit $LASTEXITCODE) — SQLite/bindings broken" }
+          Write-Host "hatch-all.js --preview ok"
 
       - uses: actions/upload-artifact@v4
         if: env.KIP_TARGET == 'installer'

--- a/build/after-pack.js
+++ b/build/after-pack.js
@@ -21,7 +21,13 @@ exports.default = async function afterPack (context) {
   }
   await fs.promises.cp(src, dst, { recursive: true })
 
-  for (const probe of ['lib/skills.js', 'node_modules/gray-matter/package.json']) {
+  for (const probe of [
+    'lib/skills.js',
+    'node_modules/gray-matter/package.json',
+    // vendored by packaging/*/build.sh (Electron-ABI, not in scripts/package.json)
+    'node_modules/better-sqlite3/build/Release/better_sqlite3.node',
+    'node_modules/bindings/package.json'
+  ]) {
     if (!fs.existsSync(path.join(dst, probe))) {
       throw new Error(`after-pack: ${probe} missing after copy`)
     }

--- a/packaging/linux/build.sh
+++ b/packaging/linux/build.sh
@@ -87,6 +87,19 @@ fi
 step "rebuild better-sqlite3 for Electron $ELECTRON_VERSION"
 ( cd "$APP_DIR/static" && npx --yes "@electron/rebuild@4.0.1" -v "$ELECTRON_VERSION" -f --only better-sqlite3 )
 
+# The retrieval layer's db.js does `require('better-sqlite3')` but it's not in
+# scripts/package.json — it resolves from the app's node_modules by walking up
+# the tree. That walk-up doesn't work for a child `node` process spawned inside
+# app.asar.unpacked/scripts (it can't cross into the packed asar for bindings/).
+# Vendor the Electron-ABI build (+ its runtime deps) into scripts/node_modules
+# so it resolves locally — picked up by both the folder asar-pack and the
+# electron-builder afterPack copy of static/scripts.
+step "vendor better-sqlite3 into scripts/node_modules"
+for m in better-sqlite3 bindings file-uri-to-path; do
+  rm -rf "$APP_DIR/static/scripts/node_modules/$m"
+  cp -a "$APP_DIR/static/node_modules/$m" "$APP_DIR/static/scripts/node_modules/$m"
+done
+
 # --- 6. package --------------------------------------------------------------
 # KIP_TARGET=installer  -> electron-builder: AppImage (self-updating) + tar.gz
 #                          + latest-linux.yml  (#38, feeds electron-updater)

--- a/packaging/windows/build.ps1
+++ b/packaging/windows/build.ps1
@@ -91,6 +91,19 @@ npx --yes "@electron/rebuild@4.0.1" -v $ELECTRON_VERSION -f --only better-sqlite
 Pop-Location
 if ($LASTEXITCODE) { throw 'better-sqlite3 rebuild failed' }
 
+# The retrieval layer's db.js does `require('better-sqlite3')` but it's not in
+# scripts/package.json — it resolves from the app's node_modules by walking up
+# the tree, which doesn't work for a child node process spawned inside
+# app.asar.unpacked\scripts. Vendor the Electron-ABI build (+ runtime deps)
+# into scripts\node_modules so it resolves locally — both the folder asar-pack
+# and the electron-builder afterPack copy pick it up.
+Step 'vendor better-sqlite3 into scripts\node_modules'
+foreach ($m in 'better-sqlite3','bindings','file-uri-to-path') {
+  $mDst = "$APP_DIR\static\scripts\node_modules\$m"
+  if (Test-Path $mDst) { Remove-Item $mDst -Recurse -Force }
+  RC "$APP_DIR\static\node_modules\$m" $mDst @('/E')
+}
+
 # --- 6. package -------------------------------------------------------------
 # KIP_TARGET=installer -> electron-builder: NSIS Kip-Setup-<version>.exe
 #                         + latest.yml  (#38, feeds electron-updater)


### PR DESCRIPTION
**User hit this testing the installer:** Hatch fails with an error about the asar / better-sqlite3 / scripts.

## Root cause

`scripts/lib/db.js` does `require('better-sqlite3')`, but better-sqlite3 is **not** in `scripts/package.json` — the retrieval layer resolved it from the app's `node_modules` by walking up the directory tree. That works for the app's own main process, but **not** for a child `node` process spawned inside `app.asar.unpacked/scripts`: even when better-sqlite3 itself is reachable, its `bindings` dependency (which loads `better_sqlite3.node`) is packed inside `app.asar`, out of the child's filesystem reach.

Affects the **folder-zip build too** (shipped in v0.2.2) — not just the new installer. The CI smoke test only ran `reminders.js`, which is pure JS and never touches SQLite, so it was never caught.

## Fix

- `packaging/{linux/build.sh,windows/build.ps1}`: after the Electron-ABI `@electron/rebuild`, vendor `better-sqlite3` + `bindings` + `file-uri-to-path` into `static/scripts/node_modules/` so `db.js` resolves them locally. Both the folder asar-pack and the electron-builder `afterPack` copy pick it up automatically.
- `after-pack.js`: assert the vendored `.node` + `bindings` landed.
- Smoke tests now run `hatch-all.js --preview` (which opens the DB) on **both** targets.

## Follow-up

If the folder build is confirmed broken for Hatch on v0.2.2, this warrants a **v0.2.3** patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)