### PR TITLE
electron: IPC for LLM connectors — list / install / remove (#57)

### DIFF
--- a/src/electron/electron/handler.cljs
+++ b/src/electron/electron/handler.cljs
@@ -506,11 +506,20 @@
 (defmethod handle :saveLlmConfig [_ [_ vault-root config]]
   (llm/save-llm-config! vault-root config))
 
-(defmethod handle :testLlmConnection [_ [_ candidate]]
-  (llm/test-llm-connection! candidate))
+(defmethod handle :testLlmConnection [_ [_ vault-root candidate]]
+  (llm/test-llm-connection! vault-root candidate))
 
 (defmethod handle :probeLocalLlm [_ [_ base-url]]
   (llm/probe-local! base-url))
+
+(defmethod handle :listLlmProviders [_ [_ vault-root]]
+  (llm/list-providers! vault-root))
+
+(defmethod handle :installConnector [_ [_ vault-root tgz-path-or-url]]
+  (llm/install-connector! vault-root tgz-path-or-url))
+
+(defmethod handle :removeConnector [_ [_ vault-root id]]
+  (llm/remove-connector! vault-root id))
 
 (defmethod handle :skillsList [_ [_ vault-root]]
   (skills/list! vault-root))

--- a/src/electron/electron/llm.cljs
+++ b/src/electron/electron/llm.cljs
@@ -17,6 +17,7 @@
             [promesa.core :as p]))
 
 (def llm-lib (js/require (.join node-path wiki/scripts-dir "lib" "llm.js")))
+(def connectors-lib (js/require (.join node-path wiki/scripts-dir "lib" "connectors.js")))
 
 (defn get-llm-config!
   "Returns the parsed <graph>/.henhouse/llm.json, or null if it doesn't
@@ -34,10 +35,51 @@
 (defn test-llm-connection!
   "Fires a trivial LLM call against `candidate` (a CLJS map: {:provider
   :apiKey :model :baseUrl}, i.e. the settings form's current, possibly
-  unsaved values — not whatever's already saved). Never rejects — resolves
-  to {success true/false, reply/error}."
-  [candidate]
-  (.testConnection llm-lib (bean/->js candidate)))
+  unsaved values — not whatever's already saved). `vault-root` lets a
+  graph-local connector be resolved. Never rejects — resolves to {success
+  true/false, reply/error}."
+  [vault-root candidate]
+  (.testConnection llm-lib (bean/->js candidate)
+                   #js {:vaultRoot (or vault-root js/undefined)}))
+
+(defn list-providers!
+  "[{id label fields ready} …] — every connector available to this graph
+  (the 5 built-ins + any bundled/graph-local ones), each with its declared
+  form fields and whether its *saved* config in <graph>/.henhouse/llm.json
+  is already complete (spec.isReady). Synchronous."
+  [vault-root]
+  (let [vr (or vault-root js/undefined)
+        cfg (.loadLLMConfig llm-lib vr)
+        providers (or (some-> cfg .-providers) #js {})
+        registry (.loadConnectors connectors-lib vr)]
+    (.map (.list registry)
+          (fn [^js spec]
+            (let [block (or (aget providers (.-id spec)) #js {})
+                  resolved (.resolveConfig connectors-lib spec block)]
+              #js {:id     (.-id spec)
+                   :label  (.-label spec)
+                   :fields (.-fields spec)
+                   :ready  (try (boolean (.isReady spec resolved))
+                                (catch :default _ false))})))))
+
+(defn install-connector!
+  "Installs a connector from a .tgz file path or an https URL into
+  <graph>/.henhouse/connectors/. Only @kip-ai/* packages are accepted.
+  Never rejects — resolves to #js {ok true id name version} / {ok false error}."
+  [vault-root tgz-path-or-url]
+  (-> (.installConnectorFromTarball connectors-lib tgz-path-or-url
+                                    (or vault-root js/undefined))
+      (p/catch (fn [^js e]
+                 #js {:ok false :error (or (.-message e) (str e))}))))
+
+(defn remove-connector!
+  "Removes an installed connector by id. Returns #js {ok true id} /
+  {ok false error}."
+  [vault-root id]
+  (try
+    (.removeConnector connectors-lib id (or vault-root js/undefined))
+    (catch :default e
+      #js {:ok false :error (or (.-message e) (str e))})))
 
 (defn probe-local!
   "GET <base-url>/models — Ollama serves it at its OpenAI-compatible path, as

--- a/src/main/frontend/components/llm_settings.cljs
+++ b/src/main/frontend/components/llm_settings.cljs
@@ -88,7 +88,7 @@
   (let [provider @*provider
         fields (get @*fields provider (empty-provider-fields))
         candidate (assoc fields :provider (name provider))]
-    (-> (ipc/ipc "testLlmConnection" candidate)
+    (-> (ipc/ipc "testLlmConnection" (vault-root) candidate)
         (p/then (fn [result] (reset! *test-result (bean/->clj result))))
         (p/catch (fn [err] (reset! *test-result {:success false :error (str err)})))
         (p/finally (fn [] (reset! *testing? false))))))


### PR DESCRIPTION
Third step of the connector epic (**#62**), first one on the app side. Needs the retrieval-layer connector host — kip `5ecb122` (#55 + #56), which is on `kip@main`, so the next app build picks it up.

## What

`electron.llm` bridges to `lib/connectors.js`:

| bridge fn | IPC channel | returns |
|---|---|---|
| `list-providers!` | `listLlmProviders` | `[{id, label, fields, ready}]` — every connector for the graph (5 built-ins + bundled + graph-local); `ready` = `spec.isReady()` against the saved `<graph>/.henhouse/llm.json` block |
| `install-connector!` | `installConnector` | `{ok, id, name, version}` / `{ok:false, error}` — never rejects; `.tgz` path or https URL; `@kip-ai/*` only |
| `remove-connector!` | `removeConnector` | `{ok}` / `{ok:false, error}` |

`test-llm-connection!` now takes `vault-root` and threads it as `{vaultRoot}`, so a **graph-local** connector's `testConnection` resolves. `:testLlmConnection` gains the arg; `llm_settings.cljs` passes `(vault-root)` at its one call site.

## Not in this PR

The settings-UI rewrite (dropdown + form built from `listLlmProviders`, `.tgz` picker, opt-in visibility for the managed "Kip (managed)" connector) is **#58**. Registry-based readiness + the `402` plan-limit mapping in `handler/llm.cljs` is **#59**.

## Checks

- `:app` + `:electron` shadow-cljs targets compile clean (0 warnings)
- clj-kondo clean on all 3 changed files
- 204/204 cljs tests pass

(No electron/IPC test runner exists in this repo — verified by compile + review, per the existing `electron.llm` / `electron.skills` bridges which are likewise untested.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)