### PR TITLE
handler/llm: registry-based readiness + a 402 usage-limit case (#59)

### DIFF
--- a/src/main/frontend/handler/llm.cljs
+++ b/src/main/frontend/handler/llm.cljs
@@ -3,11 +3,12 @@
   Peck and Hatch panels can tell the user up front when no provider is set —
   instead of failing on the first call.
 
-  `configured?` is deliberately strict: it wants an explicit provider plus that
-  provider's required credentials *in the config file*, not an ambient fallback
-  (an Anthropic CLI profile, PROVIDER/*_API_KEY env vars). The retrieval layer
-  will still use those fallbacks if present — this check just decides whether to
-  nudge the user toward Settings → LLM."
+  Readiness is decided by the connector registry: `refresh!` caches
+  `listLlmProviders` (each provider's `ready` = its ProviderSpec's own
+  `isReady` against the resolved config) alongside the selected provider, and
+  `configured?` just reads the selected one's flag. `configured?` also takes a
+  bare config map (no registry) — then it falls back to a generic 'explicit
+  provider + a non-blank apiKey in llm.json' check."
   (:require [cljs-bean.core :as bean]
             [clojure.string :as string]
             [electron.ipc :as ipc]
@@ -18,35 +19,34 @@
 (defn- present? [s]
   (and (string? s) (not (string/blank? s))))
 
-(defn- provider-ready?
-  "The fields <graph>/.henhouse/llm.json must carry for `provider` to work
-  without any env-var / ambient-credential fallback."
-  [provider {:keys [apiKey model baseUrl]}]
-  (case provider
-    "anthropic"            (present? apiKey)
-    ("openai" "deepseek")  (and (present? apiKey) (present? model))
-    "other"                (and (present? apiKey) (present? model) (present? baseUrl))
-    "local"                (and (present? model) (present? baseUrl))
-    false))
-
 (defn configured?
-  "Given the parsed llm.json map (or nil), is a provider explicitly set up?"
-  [cfg]
-  (boolean
-   (when-let [provider (some-> cfg :provider)]
-     (provider-ready? provider (get-in cfg [:providers (keyword provider)])))))
+  "Is the config's selected provider ready to use? Prefers the readiness flag
+  from `providers` (a cached `listLlmProviders` result); falls back to
+  'explicit provider + a non-blank apiKey in llm.json' when the registry
+  isn't available or doesn't know the provider."
+  ([cfg] (configured? cfg nil))
+  ([cfg providers]
+   (boolean
+    (when-let [provider (some-> cfg :provider not-empty)]
+      (if-let [p (some #(when (= (:id %) provider) %) providers)]
+        (:ready p)
+        (present? (get-in cfg [:providers (keyword provider) :apiKey])))))))
 
 (defn- vault-root []
   (config/get-repo-dir (state/get-current-repo)))
 
 (defn refresh!
-  "Re-read llm.json and cache the result in the app db under :kip/llm. Call on
-  panel mount and after an LLM settings save. Never throws."
+  "Re-read llm.json + the connector list and cache them in the app db under
+  :kip/llm. Call on panel mount and after an LLM settings save. Never throws."
   []
-  (-> (ipc/ipc "getLlmConfig" (vault-root))
-      (p/then (fn [result]
-                (state/set-state! :kip/llm {:loaded? true
-                                            :configured? (configured? (some-> result bean/->clj))})))
+  (-> (p/let [cfg-js (ipc/ipc "getLlmConfig" (vault-root))
+              providers-js (ipc/ipc "listLlmProviders" (vault-root))]
+        (let [cfg (some-> cfg-js bean/->clj)
+              providers (vec (js->clj providers-js :keywordize-keys true))]
+          (state/set-state! :kip/llm {:loaded? true
+                                      :provider (:provider cfg)
+                                      :providers providers
+                                      :configured? (configured? cfg providers)})))
       (p/catch (fn [_]
                  (state/set-state! :kip/llm {:loaded? true :configured? false})))))
 
@@ -68,7 +68,14 @@
             {:title "The provider rejected your API key."
              :hint  "Check the key in Settings → LLM (and that it matches the selected provider)."}
 
-            #"(?i)\(429\)|rate.?limit|too many requests|quota|insufficient_quota"
+            ;; 402 = the managed Kip backend's quota/budget response; also
+            ;; OpenAI's insufficient_quota (billing exhausted, not "slow down").
+            ;; Checked before 429 so those claim the token.
+            #"(?i)\(402\)|insufficient_quota|payment required|plan limit|budget (?:exceeded|limit|reached)|over budget"
+            {:title "You've hit a usage or billing limit."
+             :hint  "This provider is out of quota or budget for now. Check your plan / billing, or ask your Kip backend admin to raise the limit."}
+
+            #"(?i)\(429\)|rate.?limit|too many requests|quota"
             {:title "The provider is rate-limiting you."
              :hint  "Wait a minute and try again — or check your plan's usage limits."}
 

--- a/src/test/frontend/handler/llm_test.cljs
+++ b/src/test/frontend/handler/llm_test.cljs
@@ -2,66 +2,66 @@
   (:require [clojure.test :refer [deftest testing is are]]
             [frontend.handler.llm :as llm]))
 
+;; A `listLlmProviders` result: [{:id :label :fields :source :ready} …].
+(def ^:private registry
+  [{:id "anthropic" :ready true}
+   {:id "openai" :ready false}
+   {:id "deepseek" :ready true}
+   {:id "kip" :ready true :source "graph-local"}])
+
 (deftest configured?-nil-or-empty
-  (testing "no config file / empty map → not configured"
+  (testing "no config / no provider → not configured"
     (is (false? (llm/configured? nil)))
     (is (false? (llm/configured? {})))
-    (is (false? (llm/configured? {:provider "anthropic"})))
-    (is (false? (llm/configured? {:provider "anthropic" :providers {}})))))
+    (is (false? (llm/configured? {:provider ""})))
+    (is (false? (llm/configured? nil registry)))
+    (is (false? (llm/configured? {:provider "anthropic"} nil)))))
 
-(deftest configured?-anthropic
-  (testing "anthropic needs an explicit api key — no ambient fallback"
-    (is (true?  (llm/configured? {:provider "anthropic"
-                                  :providers {:anthropic {:apiKey "sk-ant-xxx"}}})))
-    (is (false? (llm/configured? {:provider "anthropic"
-                                  :providers {:anthropic {:apiKey "" :model "claude-x"}}})))
-    (is (false? (llm/configured? {:provider "anthropic"
-                                  :providers {:anthropic {:apiKey "   "}}})))))
+(deftest configured?-uses-the-registry-ready-flag
+  (testing "with a providers list, configured? is just that provider's :ready"
+    (is (true?  (llm/configured? {:provider "anthropic"} registry)))
+    (is (true?  (llm/configured? {:provider "deepseek"} registry)))
+    (is (false? (llm/configured? {:provider "openai"} registry))
+        "openai's spec says it isn't ready (no key/model) — regardless of the file")
+    (is (true?  (llm/configured? {:provider "kip"} registry))
+        "an installed connector is configured when its spec says so")))
 
-(deftest configured?-openai-deepseek
-  (testing "openai/deepseek need key AND model"
-    (are [x] (true? (llm/configured? x))
-      {:provider "openai"   :providers {:openai   {:apiKey "k" :model "gpt-4o-mini"}}}
-      {:provider "deepseek" :providers {:deepseek {:apiKey "k" :model "deepseek-chat"}}})
-    (are [x] (false? (llm/configured? x))
-      {:provider "openai"   :providers {:openai   {:apiKey "k" :model ""}}}
-      {:provider "openai"   :providers {:openai   {:apiKey "" :model "gpt-4o-mini"}}}
-      {:provider "deepseek" :providers {:deepseek {:model "deepseek-chat"}}})))
+(deftest configured?-registry-wins-over-the-file
+  (testing "the file's fields don't matter once the registry has spoken"
+    (is (false? (llm/configured? {:provider "openai"
+                                  :providers {:openai {:apiKey "k" :model "gpt-4o-mini"}}}
+                                 registry)))
+    (is (true?  (llm/configured? {:provider "anthropic" :providers {:anthropic {:apiKey ""}}}
+                                 registry)))))
 
-(deftest configured?-local
-  (testing "local needs base URL AND model, no key"
-    (is (true?  (llm/configured? {:provider "local"
-                                  :providers {:local {:baseUrl "http://localhost:11434/v1" :model "llama3.1"}}})))
-    (is (false? (llm/configured? {:provider "local"
-                                  :providers {:local {:baseUrl "http://localhost:11434/v1"}}})))
-    (is (false? (llm/configured? {:provider "local"
-                                  :providers {:local {:model "llama3.1"}}})))))
-
-(deftest configured?-other
-  (testing "other needs key, model AND base URL"
-    (is (true?  (llm/configured? {:provider "other"
-                                  :providers {:other {:apiKey "k" :model "m" :baseUrl "https://x/v1"}}})))
-    (is (false? (llm/configured? {:provider "other"
-                                  :providers {:other {:apiKey "k" :model "m"}}})))))
-
-(deftest configured?-ignores-other-providers-fields
-  (testing "only the *selected* provider's fields matter"
-    (is (false? (llm/configured? {:provider "anthropic"
-                                  :providers {:anthropic {:apiKey ""}
-                                              :deepseek  {:apiKey "k" :model "deepseek-chat"}}})))
-    (is (true?  (llm/configured? {:provider "deepseek"
-                                  :providers {:anthropic {:apiKey ""}
-                                              :deepseek  {:apiKey "k" :model "deepseek-chat"}}})))))
-
-(deftest configured?-unknown-provider
-  (is (false? (llm/configured? {:provider "kip" :providers {:kip {:apiKey "" :model ""}}}))))
+(deftest configured?-fallback-without-a-registry
+  (testing "no registry (or an unknown provider) → explicit provider + non-blank apiKey in the file"
+    (is (true?  (llm/configured? {:provider "kip" :providers {:kip {:apiKey "kip_x"}}})))
+    (is (false? (llm/configured? {:provider "kip" :providers {:kip {:apiKey ""}}})))
+    (is (false? (llm/configured? {:provider "kip" :providers {}})))
+    (is (true?  (llm/configured? {:provider "anthropic" :providers {:anthropic {:apiKey "sk-ant-xxx"}}})))
+    (is (false? (llm/configured? {:provider "anthropic" :providers {:anthropic {:apiKey "   "}}})))
+    (testing "only the *selected* provider's block is looked at"
+      (is (false? (llm/configured? {:provider "anthropic"
+                                    :providers {:anthropic {:apiKey ""}
+                                                :deepseek  {:apiKey "k"}}})))
+      (is (true?  (llm/configured? {:provider "deepseek"
+                                    :providers {:anthropic {:apiKey ""}
+                                                :deepseek  {:apiKey "k"}}}))))
+    (testing "a provider absent from the registry falls back too"
+      (is (true?  (llm/configured? {:provider "kip" :providers {:kip {:apiKey "kip_x"}}}
+                                   [{:id "anthropic" :ready true}]))))))
 
 (deftest humanize-error-classification
   (are [raw expected-title] (= expected-title (:title (llm/humanize-error raw)))
     "api.deepseek.com request failed (401): Authentication Fails"  "The provider rejected your API key."
     "invalid x-api-key"                                            "The provider rejected your API key."
     "request failed (429): rate limit exceeded"                    "The provider is rate-limiting you."
-    "insufficient_quota"                                           "The provider is rate-limiting you."
+    "you exceeded your quota (429)"                                "The provider is rate-limiting you."
+    "request failed (402): budget exceeded for this key"           "You've hit a usage or billing limit."
+    "insufficient_quota"                                           "You've hit a usage or billing limit."
+    "Error: Payment Required"                                      "You've hit a usage or billing limit."
+    "Your monthly plan limit is reached"                           "You've hit a usage or billing limit."
     "fetch failed"                                                 "Couldn't reach the LLM provider."
     "connect ECONNREFUSED 127.0.0.1:11434"                         "Couldn't reach the LLM provider."
     "getaddrinfo ENOTFOUND api.example"                            "Couldn't resolve the provider's address."
@@ -70,6 +70,11 @@
     "OPENAI_MODEL is required when PROVIDER=openai"                "The LLM provider isn't fully set up."
     "model gpt-9 does not exist or you do not have access"         "That model isn't available for this provider."
     "request failed (503): service unavailable"                    "The provider had a server error."))
+
+(deftest humanize-error-402-beats-429
+  (testing "insufficient_quota is billing-exhausted, not rate-limiting"
+    (is (= "You've hit a usage or billing limit."
+           (:title (llm/humanize-error "openai (429): You exceeded your current quota. insufficient_quota"))))))
 
 (deftest humanize-error-unmatched-keeps-raw
   (let [{:keys [title hint raw]} (llm/humanize-error "something weird\n  at stack")]


### PR DESCRIPTION
Fifth step of the connector epic (**#62**). On top of #57 (#64) + #58 (#66), now on `version/file`.

## What

**`configured?`** no longer hardcodes the 5 providers' field rules. `refresh!` now also caches `listLlmProviders`, and `configured?` reads the selected provider's `ready` flag — i.e. its `ProviderSpec`'s own `isReady` against the resolved config. A bare config map (unit tests, or a provider the registry doesn't know) falls back to *"explicit provider + a non-blank apiKey in llm.json"*. `provider-ready?` (the `case`) is gone.

**`humanize-error`** — new case, checked before the 429 one:

```
#"(?i)\(402\)|insufficient_quota|payment required|plan limit|budget …"
→ "You've hit a usage or billing limit."
  + hint: check plan/billing, or ask your Kip backend admin to raise the limit
```

`402` is the managed backend's quota/budget response; `insufficient_quota` (OpenAI billing exhausted) moves here from the rate-limit bucket where it never really belonged. Title is worded to fit both (not Kip-specific) since it also fires for direct OpenAI.

`llm_test.cljs` rewritten for the registry path + the fallback + the reclassification.

## Acceptance

- ✅ `configured?` true for `{:provider "kip" :providers {:kip {:apiKey "kip_x"}}}` (fallback path).
- ✅ a raw error containing `(402)` → the usage-limit title.

## Checks

`:app` + `:test` compile clean · clj-kondo clean · 202/202 cljs tests.

## Out of scope

Calling a connector's own `spec.humanizeError` from the renderer needs an IPC round-trip (`handler/llm.cljs` is renderer-side, can't `js/require`). Deferred until a connector needs error mapping beyond regex — the `402` case covers `@kip-ai/connector`'s documented custom error.

## Next

#60 (docs / `.env.example`) · #61 (the `@kip-ai/connector` package — own repo, mocked-fetch tests; `baseUrl` default `api.kip-ai.be`, overridable for the LAN backend).

🤖 Generated with [Claude Code](https://claude.com/claude-code)