### PR TITLE
release: v0.3.5 — reasoning models first-class; connector docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,16 @@
 All notable changes to the Kip desktop app. The retrieval layer has its own
 changelog at [JWE24-code/kip](https://github.com/JWE24-code/kip/blob/main/CHANGELOG.md).
 
-## [0.3.5] — 2026-08-29
+## [0.3.5] — 2026-08-30
 
-- **Reasoning models are first-class** — pick `deepseek-reasoner` (or
-  OpenAI's `o1` / `o3` / `o4-mini`) and Kip no longer wastes a round-trip
-  on every call discovering they don't support forced-JSON mode. They still
-  think before answering, so they're slower — best kept for the managed
-  backend, which routes only the workloads that benefit to one.
+- **Reasoning models are first-class** — pick `deepseek-reasoner`,
+  `deepseek-r1`, OpenAI's `o1` / `o3` / `o4-mini` or similar and Kip no
+  longer wastes a round-trip on every call discovering they don't support
+  forced-JSON mode: the common ones are known by name, and any other model
+  that rejects the parameter is remembered for the rest of the session
+  after the first time. They still think before answering, so they're
+  slower — best kept for the managed backend, which routes only the
+  workloads that benefit to one.
 - **Docs: the managed connector and Add-a-connector, explained** — Settings
   → LLM now has user docs for the "Kip (managed)" provider, installing an
   `@kip-ai/*` connector from a `.tgz`, and why only that name is allowed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to the Kip desktop app. The retrieval layer has its own
 changelog at [JWE24-code/kip](https://github.com/JWE24-code/kip/blob/main/CHANGELOG.md).
 
+## [0.3.5] — 2026-08-29
+
+- **Reasoning models are first-class** — pick `deepseek-reasoner` (or
+  OpenAI's `o1` / `o3` / `o4-mini`) and Kip no longer wastes a round-trip
+  on every call discovering they don't support forced-JSON mode. They still
+  think before answering, so they're slower — best kept for the managed
+  backend, which routes only the workloads that benefit to one.
+- **Docs: the managed connector and Add-a-connector, explained** — Settings
+  → LLM now has user docs for the "Kip (managed)" provider, installing an
+  `@kip-ai/*` connector from a `.tgz`, and why only that name is allowed
+  (a connector runs in Kip's own process).
+
 ## [0.3.4] — 2026-08-29
 
 - **Fixed: Peck crashed on a stale search index** — if the index still

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "kip",
-    "version": "0.3.4",
+    "version": "0.3.5",
     "private": true,
     "main": "static/electron.js",
     "devDependencies": {

--- a/resources/package.json
+++ b/resources/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kip",
   "productName": "Kip",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "main": "electron.js",
   "author": "Joeri Weitmann",
   "license": "AGPL-3.0",

--- a/src/main/frontend/version.cljs
+++ b/src/main/frontend/version.cljs
@@ -1,3 +1,3 @@
 (ns ^:no-doc frontend.version)
 
-(defonce version "0.3.4")
+(defonce version "0.3.5")


### PR DESCRIPTION
## What ships

**#68 (direct-provider half)** — reasoning models (`deepseek-reasoner`,
OpenAI `o1`/`o3`/`o4-mini`) no longer cost a wasted round-trip on every
`json:true` call. The retrieval layer detects them by name and asks for JSON
in the prompt instead of sending the `response_format` parameter they reject.
Managed-backend routing to a reasoner is still tracked on #68 (backend
adapter work).

**#60** — the managed **Kip (managed)** provider and the **Add a connector**
flow (`@kip-ai/*` `.tgz`, allowlist rationale, connector directory) are now
documented for users in the retrieval layer's `GETTING-STARTED.md`, plus
`FEATURES.md` / `DEVELOPMENT.md` / `.env.example`.

## Contents

- `version.cljs` + both `package.json` → `0.3.5`
- `CHANGELOG.md` → `[0.3.5]`
- Carries kip `a247c0b` (JWE24-code/kip#17, merged) — the build checks out
  kip `main` HEAD.

No app-code change this release — it's the retrieval layer + docs + version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)