### PR TITLE
Fix: scheduled deep groom was always saved disabled (+ v0.3.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to the Kip desktop app. The retrieval layer has its own
 changelog at [JWE24-code/kip](https://github.com/JWE24-code/kip/blob/main/CHANGELOG.md).
 
+## [0.3.6] — 2026-08-30
+
+- **Fixed: "Run the deep groom on a schedule" never stuck** — ticking the
+  box in Settings → Features did nothing: the day/time controls never
+  appeared and the schedule was always saved as *off*. The setting crossed
+  the process boundary with the wrong key shape, so the main process read
+  every field as blank and wrote back "disabled". The scheduled deep groom
+  has been non-functional since it shipped in 0.3.0; it works now.
+
 ## [0.3.5] — 2026-08-30
 
 - **Reasoning models are first-class** — pick `deepseek-reasoner`,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "kip",
-    "version": "0.3.5",
+    "version": "0.3.6",
     "private": true,
     "main": "static/electron.js",
     "devDependencies": {

--- a/resources/package.json
+++ b/resources/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kip",
   "productName": "Kip",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "main": "electron.js",
   "author": "Joeri Weitmann",
   "license": "AGPL-3.0",

--- a/src/electron/electron/groom_scheduler.cljs
+++ b/src/electron/electron/groom_scheduler.cljs
@@ -62,8 +62,7 @@
                                          :silent true}))))))))
 
 (defn- tick! []
-  (let [{:keys [enabled day time]} (some-> (cfgs/get-item :groom/schedule)
-                                           (js->clj :keywordize-keys true))]
+  (let [{:keys [enabled day time]} (cfgs/get-item :groom/schedule)]
     (when (and enabled (not @*running?) (number? day) time)
       (when-let [prev (prev-occurrence day time (js/Date.now))]
         (when (> prev (or (cfgs/get-item :groom/last-run) 0))
@@ -72,8 +71,7 @@
 (defn schedule-info
   "The renderer's view: current schedule + last/next run (epoch ms or nil)."
   []
-  (let [{:keys [enabled day time] :as sched} (some-> (cfgs/get-item :groom/schedule)
-                                                     (js->clj :keywordize-keys true))]
+  (let [{:keys [enabled day time] :as sched} (cfgs/get-item :groom/schedule)]
     #js {:enabled (boolean enabled)
          :day     (if (number? day) day 3)          ; default Wednesday
          :time    (or time "03:00")
@@ -85,14 +83,15 @@
 (defn set-schedule!
   "Persist a schedule from the renderer. Marks now as the last run when the
   schedule is first turned on, so an already-passed slot this week doesn't
-  fire immediately."
-  [{:strs [enabled day time]}]
+  fire immediately. `sched` arrives as a CLJS map with keyword keys (the
+  \"main\" IPC channel runs args through bean/->clj before dispatch)."
+  [{:keys [enabled day time]}]
   (let [enabled (boolean enabled)
         day (if (number? day) (int day) 3)
         time (or (and (parse-hhmm time) time) "03:00")
         was (cfgs/get-item :groom/schedule)]
     (cfgs/set-item! :groom/schedule {:enabled enabled :day day :time time})
-    (when (and enabled (not (:enabled (some-> was (js->clj :keywordize-keys true)))))
+    (when (and enabled (not (:enabled was)))
       (cfgs/set-item! :groom/last-run (js/Date.now)))
     (schedule-info)))
 

--- a/src/electron/electron/handler.cljs
+++ b/src/electron/electron/handler.cljs
@@ -594,7 +594,10 @@
   (groom-scheduler/schedule-info))
 
 (defmethod handle :setGroomSchedule [_ [_ sched]]
-  (groom-scheduler/set-schedule! (js->clj sched)))
+  ;; `sched` is already a CLJS map — the "main" channel runs args through
+  ;; bean/->clj before dispatch. (js->clj on it would be a no-op; passing it
+  ;; straight through is clearer.)
+  (groom-scheduler/set-schedule! sched))
 
 (defmethod handle :wikiChat [_ [_ vault-root question trace?]]
   (wiki/peck! vault-root question (boolean trace?)))

--- a/src/main/frontend/version.cljs
+++ b/src/main/frontend/version.cljs
@@ -1,3 +1,3 @@
 (ns ^:no-doc frontend.version)
 
-(defonce version "0.3.5")
+(defonce version "0.3.6")


### PR DESCRIPTION
## The bug

Ticking **Settings → Features → "Run the deep groom on a schedule"** does
nothing — the day/time controls never appear, and the schedule is always
persisted as *off*. Broken since the feature shipped in **0.3.0**.

## Cause

The `"main"` IPC channel runs every incoming arg through `bean/->clj`
before `handle` dispatch, so a defmethod receives **CLJS maps with keyword
keys**. But:

- `groom-scheduler/set-schedule!` destructured `{:strs [enabled day time]}`
  (string keys) → all `nil`
- the `:setGroomSchedule` handler additionally ran `(js->clj sched)` on the
  already-converted map

So `set-schedule!` saw `enabled`/`day`/`time` as blank, wrote
`{:enabled false, :day 3, :time "03:00"}` on every call, and returned it.
The renderer optimistically shows the controls, then the IPC response
(`:enabled false`) resets its state and they vanish.

## Fix

- `set-schedule!`: `{:strs […]}` → `{:keys […]}`
- handler: drop the redundant `(js->clj sched)`
- drop the now-pointless `(js->clj … :keywordize-keys true)` wrappers around
  `cfgs/get-item` results in `tick!` / `schedule-info` / the `was` check —
  `electron.configs` stores EDN and hands back CLJS

`npx shadow-cljs compile electron` — clean, 0 warnings.

Bumps `version.cljs` + both `package.json` to **0.3.6** and adds the
CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)