### PR TITLE
Move the deep-groom schedule into Coop status (v0.3.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to the Kip desktop app. The retrieval layer has its own
 changelog at [JWE24-code/kip](https://github.com/JWE24-code/kip/blob/main/CHANGELOG.md).
 
+## [0.3.7] — 2026-08-30
+
+- **The deep-groom schedule moved to Coop status** — it's no longer in
+  Settings → Features. The Coop status panel now reads, top to bottom:
+  the coop overview, **Groom** (run / deep-groom / last report), the weekly
+  **Schedule**, then **Recent clucks** — so everything about grooming is in
+  one place.
+
 ## [0.3.6] — 2026-08-30
 
 - **Fixed: "Run the deep groom on a schedule" never stuck** — ticking the

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "kip",
-    "version": "0.3.6",
+    "version": "0.3.7",
     "private": true,
     "main": "static/electron.js",
     "devDependencies": {

--- a/resources/package.json
+++ b/resources/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kip",
   "productName": "Kip",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "main": "electron.js",
   "author": "Joeri Weitmann",
   "license": "AGPL-3.0",

--- a/src/main/frontend/components/groom_settings.cljs
+++ b/src/main/frontend/components/groom_settings.cljs
@@ -1,5 +1,6 @@
 (ns frontend.components.groom-settings
-  "The 'schedule the deep groom' control (Settings → Features). Backed by the
+  "The 'schedule the deep groom' control — rendered in the Coop status panel
+  (frontend.components.wiki-status), under 'Schedule'. Backed by the
   :getGroomSchedule / :setGroomSchedule IPC (electron.groom-scheduler, main
   process). The schedule is global, not per-graph."
   (:require [cljs-bean.core :as bean]
@@ -59,14 +60,3 @@
           "Next: " (or (when-str nextRun) "—")
           (when lastRun (str "  ·  last run " (when-str lastRun)))
           ". Runs on the next launch if Kip was closed at that time."])])))
-
-(rum/defcs next-run-note
-  < rum/reactive
-    (rum/local nil ::s)
-    {:will-mount (fn [state] (load! (::s state)) state)}
-  [state]
-  (let [{:keys [enabled nextRun lastRun]} @(::s state)]
-    (when enabled
-      [:div.text-xs.opacity-60
-       "Scheduled deep groom — next " (or (when-str nextRun) "—")
-       (when lastRun (str ", last " (when-str lastRun)))])))

--- a/src/main/frontend/components/settings.cljs
+++ b/src/main/frontend/components/settings.cljs
@@ -5,7 +5,6 @@
             [frontend.colors :as colors]
             [frontend.components.assets :as assets]
             [frontend.components.conversion :as conversion-component]
-            [frontend.components.groom-settings :as groom-settings]
             [frontend.components.llm-settings :as llm-settings]
             [frontend.components.skills-settings :as skills-settings]
             [frontend.components.plugins :as plugins]
@@ -708,9 +707,7 @@
      (when (util/electron?)
        (http-server-switcher-row))
      (flashcards-switcher-row enable-flashcards?)
-     (zotero-settings-row)
-     (when (util/electron?)
-       (groom-settings/schedule-row))]))
+     (zotero-settings-row)]))
 
 
 (def DEFAULT-ACTIVE-TAB-STATE [:general :general])

--- a/src/main/frontend/components/wiki_status.cljs
+++ b/src/main/frontend/components/wiki_status.cljs
@@ -1,12 +1,13 @@
 (ns frontend.components.wiki-status
-  "The Coop status panel: the last few clucks (recentClucks via
-  scripts/lib/roost.js) and the Groom workflow — a fast structural \"Run
-  groom\" and a \"Deep groom (weekly)\" that does the full LLM-heavy review
-  (per-page _Update_ reconciliation, summary drift, missing/broken links,
-  merge candidates, deeper contradictions) and writes a
-  <coop>/.roost/groom-report.md checklist. Everything goes through
-  electron.wiki, which shells out to the same CLI scripts used from the
-  terminal — one code path."
+  "The Coop status panel, top to bottom: the coop overview, the Groom
+  workflow (a fast structural \"Run groom\" and a \"Deep groom (weekly)\"
+  that does the full LLM-heavy review — per-page _Update_ reconciliation,
+  summary drift, missing/broken links, merge candidates, deeper
+  contradictions — and writes a <coop>/.roost/groom-report.md checklist),
+  the weekly-deep-groom Schedule (groom-settings/schedule-row), and the
+  last few clucks (recentClucks via scripts/lib/roost.js). Everything goes
+  through electron.wiki, which shells out to the same CLI scripts used from
+  the terminal — one code path."
   (:require [cljs-bean.core :as bean]
             [clojure.string :as string]
             [electron.ipc :as ipc]
@@ -186,14 +187,6 @@
        (coop-overview s @(get state ::pending)))
 
      [:div.mb-4
-      [:h3.text-lg.font-medium.mb-1 "Recent clucks"]
-      (cond
-        (nil? @*recent-clucks) [:div.text-sm.opacity-60 "Loading..."]
-        (:error @*recent-clucks) [:div.text-sm.text-red-500 (str "Error: " (:error @*recent-clucks))]
-        (empty? @*recent-clucks) [:div.text-sm.opacity-60 "No clucks yet."]
-        :else [:div (map (fn [entry] (cluck-entry entry)) @*recent-clucks)])]
-
-     [:div
       [:div.flex.justify-between.items-center.mb-1
        [:h3.text-lg.font-medium "Groom"]
        [:div.flex.gap-2
@@ -215,9 +208,6 @@
          (str "Last deep groom " (telemetry/ago at))
          "No deep groom recorded yet")]
 
-      (when (util/electron?)
-        [:div.mb-2 (groom-settings/next-run-note)])
-
       (cond
         @*deep-loading?
         [:div
@@ -234,7 +224,20 @@
         (some? @*groom-report)
         (groom-report @*groom-report)
 
-        :else nil)]]))
+        :else nil)]
+
+     (when (util/electron?)
+       [:div.mb-4
+        [:h3.text-lg.font-medium.mb-1 "Schedule"]
+        (groom-settings/schedule-row)])
+
+     [:div
+      [:h3.text-lg.font-medium.mb-1 "Recent clucks"]
+      (cond
+        (nil? @*recent-clucks) [:div.text-sm.opacity-60 "Loading..."]
+        (:error @*recent-clucks) [:div.text-sm.text-red-500 (str "Error: " (:error @*recent-clucks))]
+        (empty? @*recent-clucks) [:div.text-sm.opacity-60 "No clucks yet."]
+        :else [:div (map (fn [entry] (cluck-entry entry)) @*recent-clucks)])]]))
 
 (defn show-coop-status-modal! [e]
   (state/set-modal! coop-status-modal)

--- a/src/main/frontend/version.cljs
+++ b/src/main/frontend/version.cljs
@@ -1,3 +1,3 @@
 (ns ^:no-doc frontend.version)
 
-(defonce version "0.3.6")
+(defonce version "0.3.7")


### PR DESCRIPTION
Per request: the **"Run the deep groom on a schedule"** control leaves
Settings → Features and moves into the **Coop status** panel.

Coop status now reads top-to-bottom:

1. Your coop (overview)
2. **Groom** — Run groom / Deep groom (weekly) / last report
3. **Schedule** — the weekly deep-groom schedule (checkbox → day + time + next run)
4. **Recent clucks**

## Changes

- `settings.cljs` — drop `groom-settings/schedule-row` from the Features
  panel + its now-unused require.
- `wiki_status.cljs` — reorder to Groom → Schedule → Recent clucks; the
  Schedule section renders `groom-settings/schedule-row` directly (electron
  only).
- `groom_settings.cljs` — drop `next-run-note` (superseded by the full
  `schedule-row`, which shows the next run); docstring updated.

`npx shadow-cljs compile app` and `compile electron` — both clean, 0 warnings.
Bumps to **0.3.7**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)