### PR TITLE
Preference signals: kipFeedback IPC + the renderer gate

### DIFF
--- a/src/electron/electron/handler.cljs
+++ b/src/electron/electron/handler.cljs
@@ -31,6 +31,7 @@
             [electron.update :as update]
             [electron.updater :as updater]
             [electron.groom-scheduler :as groom-scheduler]
+            [electron.preference-signals :as preference-signals]
             [electron.utils :as utils]
             [electron.wiki :as wiki]
             [electron.window :as win]
@@ -598,6 +599,12 @@
   ;; bean/->clj before dispatch. (js->clj on it would be a no-op; passing it
   ;; straight through is clearer.)
   (groom-scheduler/set-schedule! sched))
+
+;; Preference signals (kip-app#73) — one content-free signal from the
+;; renderer. feedback-poster.js gates on the active provider being `kip` and
+;; strips the signal to its wire fields, so this handler stays a thin pass.
+(defmethod handle :kipFeedback [_ [_ vault-root signal]]
+  (preference-signals/post-feedback! vault-root signal))
 
 (defmethod handle :wikiChat [_ [_ vault-root question trace?]]
   (wiki/peck! vault-root question (boolean trace?)))

--- a/src/electron/electron/preference_signals.cljs
+++ b/src/electron/electron/preference_signals.cljs
@@ -1,0 +1,33 @@
+(ns electron.preference-signals
+  "In-process bridge to scripts/lib/feedback-poster.js — the electron side of
+  the preference-signals epic (kip-app#73). The renderer's content-free
+  signals (a 👍/👎 rating, a debounced behaviour event, an arena verdict)
+  come in over the :kipFeedback IPC channel and are POSTed once to the
+  managed Kip backend's /v1/feedback.
+
+  feedback-poster.js does the gating itself: postFeedback() checks the
+  active provider is `kip` and resolves { ok: false } without a request
+  otherwise, and it sanitises the signal down to the closed wire field set,
+  so nothing but { call_id, kind, enum/int } can leave. Required via
+  js/require for the same reason electron.llm does (see its docstring)."
+  (:require [cljs-bean.core :as bean]
+            ["path" :as node-path]
+            [electron.logger :as logger]
+            [electron.wiki :as wiki]
+            [promesa.core :as p]))
+
+(def ^:private feedback-lib
+  (js/require (.join node-path wiki/scripts-dir "lib" "feedback-poster.js")))
+
+(defn post-feedback!
+  "POST one preference signal. `signal` is a CLJS map — at least
+  {:call_id :kind} plus the kind's fields. Never rejects; resolves the
+  #js {:ok bool} from feedback-poster (false when the provider isn't `kip`,
+  the signal is malformed, or the request failed)."
+  [vault-root signal]
+  (-> (.postFeedback feedback-lib
+                     (bean/->js signal)
+                     #js {:vaultRoot (or vault-root js/undefined)})
+      (p/catch (fn [err]
+                 (logger/warn "[PreferenceSignals]" (str "postFeedback failed: " err))
+                 #js {:ok false}))))

--- a/src/main/frontend/handler/preference_signals.cljs
+++ b/src/main/frontend/handler/preference_signals.cljs
@@ -1,0 +1,53 @@
+(ns frontend.handler.preference-signals
+  "Renderer side of the preference-signals epic (kip-app#73).
+
+  Every mechanism — the 👍/👎 rating, the behaviour watcher, the arena — is
+  INERT unless the active LLM provider is the managed `kip` connector. The
+  gate here, `enabled?`, is the one check they all share; it reads the
+  `:provider` already cached in `:kip/llm` by `frontend.handler.llm/refresh!`
+  (called on the Peck/Hatch panels' mount and after an LLM settings save),
+  so there's no extra IPC for it.
+
+  `send!` ships one content-free signal to the managed backend via the
+  :kipFeedback IPC (electron.preference-signals → scripts/lib/feedback-poster).
+  It's fire-and-forget and best-effort: a disabled gate, a rejected IPC, or a
+  backend error all resolve to nil without disturbing anything."
+  (:require [electron.ipc :as ipc]
+            [frontend.config :as config]
+            [frontend.state :as state]
+            [promesa.core :as p]))
+
+(defn enabled?
+  "True only when the managed `kip` connector is the active provider."
+  []
+  (= "kip" (some-> (:kip/llm @state/state) :provider)))
+
+(defn- vault-root []
+  (config/get-repo-dir (state/get-current-repo)))
+
+(defn send!
+  "Post one preference signal. `signal` is a map: at least
+  {:call_id \"…\" :kind \"rating\"|\"behavior\"} plus the kind's fields
+  (:score/:scale, or :behavior/:edit_bucket). No-op unless `enabled?`.
+  Returns a promise that always resolves (never rejects)."
+  [signal]
+  (if (and (enabled?)
+           (string? (:call_id signal))
+           (:kind signal))
+    (-> (ipc/ipc "kipFeedback" (vault-root) signal)
+        (p/catch (fn [_] nil)))
+    (p/resolved nil)))
+
+(defn rate!
+  "Convenience for the 👍/👎 widget. `score` is 1 (up) or 0 (down)."
+  [call-id score]
+  (send! {:call_id call-id :kind "rating" :score score :scale 2}))
+
+(defn behavior!
+  "Convenience for the behaviour watcher. `behavior` is one of
+  \"accepted\" \"copied\" \"edited\" \"regenerated\" \"discarded\";
+  `edit-bucket` (0–4) only with \"edited\"."
+  ([call-id behavior] (behavior! call-id behavior nil))
+  ([call-id behavior edit-bucket]
+   (send! (cond-> {:call_id call-id :kind "behavior" :behavior behavior}
+            (some? edit-bucket) (assoc :edit_bucket edit-bucket)))))

--- a/src/test/frontend/handler/preference_signals_test.cljs
+++ b/src/test/frontend/handler/preference_signals_test.cljs
@@ -1,0 +1,32 @@
+(ns frontend.handler.preference-signals-test
+  (:require [clojure.test :refer [deftest testing is]]
+            [frontend.handler.preference-signals :as ps]
+            [frontend.state :as state]))
+
+(defn- with-provider [provider f]
+  (let [prev (:kip/llm @state/state)]
+    (try
+      (state/set-state! :kip/llm {:loaded? true :provider provider})
+      (f)
+      (finally (state/set-state! :kip/llm prev)))))
+
+(deftest enabled?-only-for-kip
+  (with-provider "kip" #(is (true? (ps/enabled?))))
+  (with-provider "anthropic" #(is (false? (ps/enabled?))))
+  (with-provider nil #(is (false? (ps/enabled?))))
+  (testing "no :kip/llm at all"
+    (let [prev (:kip/llm @state/state)]
+      (try
+        (state/set-state! :kip/llm nil)
+        (is (false? (ps/enabled?)))
+        (finally (state/set-state! :kip/llm prev))))))
+
+(deftest send!-no-op-unless-enabled-and-well-formed
+  (testing "returns a resolved promise, never throws, when the gate is closed"
+    (with-provider "anthropic"
+      #(is (some? (ps/send! {:call_id "c1" :kind "rating" :score 1 :scale 2})))))
+  (testing "malformed signal is dropped even when enabled"
+    (with-provider "kip"
+      #(do
+         (is (some? (ps/send! {:kind "rating"})))          ; no call_id
+         (is (some? (ps/send! {:call_id "c1"})))))))       ; no kind


### PR DESCRIPTION
Client half of the preference-signals epic (#73), the IPC layer. Depends on
kip `06a693f` (`postFeedback`, merged). **No UI yet** — the next PR adds the
👍/👎 widget.

## What's here

- **`electron.preference-signals`** — `js/require`s
  `scripts/lib/feedback-poster.js`; `post-feedback!` POSTs one signal to the
  managed backend, never rejects.
- **`handler.cljs` `:kipFeedback`** — a thin pass to `post-feedback!`.
  `feedback-poster.js` does the gating (active provider must be `kip`) and
  strips the signal to its closed wire field set, so a stray `text`/`note`
  can't ride along.
- **`frontend.handler.preference-signals`** —
  - `enabled?` — the one gate every mechanism shares:
    `(= "kip" (:provider (:kip/llm @state/state)))`. No new IPC: `:kip/llm`
    is already refreshed by `frontend.handler.llm/refresh!` on the
    Peck/Hatch panels' mount and after an LLM settings save.
  - `send!` / `rate!` / `behavior!` — fire the `:kipFeedback` IPC, but only
    when `enabled?` and the signal is well-formed. Fire-and-forget.

## Verification

`:app` and `:electron` compile clean (0 warnings).
`frontend.handler.preference-signals-test` (new) + `frontend.handler.llm-test`
green. The one failing frontend test — `block-property-query-performance`, a
timing assertion in `query_dsl_test.cljs` — is a pre-existing flake with no
connection to this change.

## Next

1. Thread the answer call's `callId` from `peckTurn` → `chat.js` JSON →
   `chat.cljs` message.
2. Mechanism 2 — the 👍/👎 widget on a Peck answer.
3. Mechanism 1 (behavioural) / arena.

🤖 Generated with [Claude Code](https://claude.com/claude-code)