### PR TITLE
Peck: Regenerate an answer + the regenerated preference signal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ changelog at [JWE24-code/kip](https://github.com/JWE24-code/kip/blob/main/CHANGE
   the coop overview, **Groom** (run / deep-groom / last report), the weekly
   **Schedule**, then **Recent clucks** — so everything about grooming is in
   one place.
+- **Regenerate a Peck answer** — every answer now has a `↻ Regenerate`
+  button that re-asks the same question and adds a fresh answer below.
+  Works on any provider. On the Kip (managed) backend a regenerate also
+  quietly tells the router the first answer missed — nothing but that one
+  bit, no text.
 - **Rate a Peck answer** — when you're on the Kip (managed) backend, a
   Peck answer now carries a small 👍 / 👎 control. It sends nothing but a
   thumbs-up or thumbs-down against that one answer — no text, no page

--- a/src/main/frontend/components/chat.cljs
+++ b/src/main/frontend/components/chat.cljs
@@ -70,7 +70,7 @@
         {:role :assistant :text (if (string/blank? note) "Nothing new to add there." note)})
 
       answer
-      {:role :assistant :text answer :steps steps :call-id callId}
+      {:role :assistant :text answer :steps steps :call-id callId :answer? true}
 
       (= intent "reminder")
       {:role :assistant :text "Reminder noted — check the Reminders panel." :steps steps}
@@ -90,22 +90,38 @@
   (reset! *poll-id nil)
   (reset! *progress nil))
 
+(defn- ask!
+  "Run one Peck turn for `question` and hand the turn->message map (plus the
+  originating `:q`) to `on-result`. Shared by a fresh send and a regenerate."
+  [question on-result *loading? *progress *poll-id]
+  (when (and (not (string/blank? question)) (not @*loading?))
+    (reset! *loading? true)
+    (start-poll! *progress *poll-id)
+    (-> (ipc/ipc "wikiChat" (vault-root) question)
+        (p/then (fn [result]
+                  (on-result (assoc (turn->message (bean/->clj result)) :q question))))
+        (p/catch (fn [error]
+                   (swap! *messages conj {:role :error :text (str error)})))
+        (p/finally (fn []
+                     (stop-poll! *progress *poll-id)
+                     (reset! *loading? false))))))
+
 (defn- send-message!
   [*loading? *progress *poll-id]
   (let [input (string/trim @*input)]
     (when (and (not (string/blank? input)) (not @*loading?))
       (reset! *input "")
       (swap! *messages conj {:role :user :text input})
-      (reset! *loading? true)
-      (start-poll! *progress *poll-id)
-      (-> (ipc/ipc "wikiChat" (vault-root) input)
-          (p/then (fn [result]
-                    (swap! *messages conj (turn->message (bean/->clj result)))))
-          (p/catch (fn [error]
-                     (swap! *messages conj {:role :error :text (str error)})))
-          (p/finally (fn []
-                       (stop-poll! *progress *poll-id)
-                       (reset! *loading? false)))))))
+      (ask! input #(swap! *messages conj %) *loading? *progress *poll-id))))
+
+(defn- regenerate!
+  "Re-run the question that produced `msg`, appending a fresh answer below it.
+  Fires the preference-signals `regenerated` behaviour signal against the old
+  answer's call id — a no-op on every provider but the managed `kip` one."
+  [{:keys [q call-id]} *loading? *progress *poll-id]
+  (when (and (not (string/blank? q)) (not @*loading?))
+    (when call-id (pref-signals/behavior! call-id "regenerated"))
+    (ask! q #(swap! *messages conj (assoc % :regen? true)) *loading? *progress *poll-id)))
 
 (defn- steps-line
   "A ⚙ line per skill the tool loop ran, above the answer."
@@ -154,7 +170,8 @@
      (when (some? @*picked) [:span {:style {:opacity 0.45}} "logged"])]))
 
 (rum/defc message-cp
-  [{:keys [role text pages steps call-id]}]
+  [{:keys [role text pages steps call-id answer? regen?] :as msg}
+   {:keys [on-regenerate busy?]}]
   [:div.py-2
    (case role
      :user
@@ -178,10 +195,25 @@
      ;; :assistant — render [[slug]] citations as real clickable page links
      ;; via the app's own markdown renderer, given a plain unsaved string.
      [:div
+      (when regen?
+        [:div {:style {:font-size "9px" :letter-spacing "0.1em" :text-transform "uppercase"
+                       :font-family "ui-monospace, SFMono-Regular, Menlo, monospace"
+                       :opacity 0.4 :margin-bottom "4px"}}
+         "↻ regenerated"])
       (when (seq steps) (steps-line steps))
       [:div.prose.prose-sm.max-w-none (block/inline-text citation-config :markdown text)]
-      (when (and call-id (pref-signals/enabled?))
-        (rate-widget call-id))])])
+      [:div {:style {:display "flex" :align-items "center" :gap "16px" :flex-wrap "wrap"}}
+       (when (and call-id (pref-signals/enabled?))
+         (rate-widget call-id))
+       (when (and answer? on-regenerate)
+         [:button {:on-click #(when-not busy? (on-regenerate msg))
+                   :disabled (boolean busy?)
+                   :title "Ask again"
+                   :style {:font-size "9px" :letter-spacing "0.1em" :text-transform "uppercase"
+                           :font-family "ui-monospace, SFMono-Regular, Menlo, monospace"
+                           :opacity (if busy? 0.3 0.6) :cursor (if busy? "default" "pointer")
+                           :background "transparent" :border "none" :padding "3px 0" :margin-top "6px"}}
+          "↻ Regenerate"])]])])
 
 (defn- first-run-showing? [llm counts]
   (and (not (first-run/dismissed?))
@@ -246,13 +278,16 @@
         messages (rum/react *messages)
         input (rum/react *input)
         submit! #(send-message! *loading? *progress *poll-id)
+        regen! (fn [msg] (regenerate! msg *loading? *progress *poll-id))
         activity (get @*progress :activity)]
     [:div.flex.flex-col {:style {:height "100%"}}
      [:div.flex-1.overflow-y-auto.px-2.pt-2
       (llm-banner/provider-banner)
       (if (empty? messages)
         (empty-state)
-        (map-indexed (fn [idx msg] (rum/with-key (message-cp msg) idx)) messages))
+        (map-indexed (fn [idx msg]
+                       (rum/with-key (message-cp msg {:on-regenerate regen! :busy? @*loading?}) idx))
+                     messages))
       (when @*loading?
         [:div.py-2
          [:div.text-sm.opacity-60 "Thinking…"]

--- a/src/test/frontend/handler/preference_signals_test.cljs
+++ b/src/test/frontend/handler/preference_signals_test.cljs
@@ -3,6 +3,19 @@
             [frontend.handler.preference-signals :as ps]
             [frontend.state :as state]))
 
+(deftest behavior!-builds-a-content-free-signal
+  (let [sent (atom nil)]
+    (with-redefs [ps/send! (fn [sig] (reset! sent sig) sig)]
+      (testing "regenerated — no edit bucket"
+        (ps/behavior! "call_1" "regenerated")
+        (is (= {:call_id "call_1" :kind "behavior" :behavior "regenerated"} @sent)))
+      (testing "edited — carries the client-side edit bucket only"
+        (ps/behavior! "call_2" "edited" 3)
+        (is (= {:call_id "call_2" :kind "behavior" :behavior "edited" :edit_bucket 3} @sent)))
+      (testing "nil edit bucket is dropped, not sent as null"
+        (ps/behavior! "call_3" "copied" nil)
+        (is (= {:call_id "call_3" :kind "behavior" :behavior "copied"} @sent))))))
+
 (defn- with-provider [provider f]
   (let [prev (:kip/llm @state/state)]
     (try


### PR DESCRIPTION
Mechanism 1 of the preference-signals epic (#73), in the **implicit-only** shape we settled on: the only behavioural signal collected is a *regenerate* (a strong "that answer missed"), and the only new UI is a Regenerate button the chat panel should have had anyway.

## What changed

- **`↻ Regenerate` button on every Peck answer** — re-asks the same question and adds a fresh answer below, tagged `↻ regenerated`. Works on any provider. Disabled while a turn is in flight.
- **`chat.cljs`**: `ask!` extracted as the shared turn runner (fresh send + regenerate both use it). `regenerate!` fires `pref-signals/behavior!` with `"regenerated"` against the prior answer's call id.
- The **signal** is gated in `behavior!`/`send!` — a no-op on every provider but the managed `kip` one. The button shows everywhere; only the telemetry is gated.

## Explicitly out of scope

No copy button, no "insert this answer as graph blocks" flow, no accept/edit/discard, no edit-distance bucketing. Those need a graph-blocks surface that doesn't exist in Peck today — promoted to its own roadmap item, judged on its own merits.

## Next (slice 2, separate PR)

The arena: on `kip`, a regenerate routes through `POST /v1/arena/completions` with `compare_to_call_id`, and a dismissable "was this better? ← A / B →" strip posts to `/v1/arena/{id}/verdict`. Blocked on the private `kip-backend` `feat/preference-signals` branch being deployed + its response contract.

## Verification

- `npx shadow-cljs compile app` — clean
- Frontend suite: 205 tests / 1733 assertions, 0 failures (204 pre-existing + 1 new `behavior!` payload-shape test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)