### PR TITLE
Preference signals: arena verdict on a regenerated answer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@ changelog at [JWE24-code/kip](https://github.com/JWE24-code/kip/blob/main/CHANGE
   button that re-asks the same question and adds a fresh answer below.
   Works on any provider. On the Kip (managed) backend a regenerate also
   quietly tells the router the first answer missed — nothing but that one
-  bit, no text.
+  bit, no text — and the re-run comes from a different model, so the new
+  answer carries a one-tap **"better than the last one?"** strip. Answer
+  it or ignore it; either way nothing but the verdict leaves the app.
 - **Rate a Peck answer** — when you're on the Kip (managed) backend, a
   Peck answer now carries a small 👍 / 👎 control. It sends nothing but a
   thumbs-up or thumbs-down against that one answer — no text, no page

--- a/src/electron/electron/handler.cljs
+++ b/src/electron/electron/handler.cljs
@@ -606,8 +606,14 @@
 (defmethod handle :kipFeedback [_ [_ vault-root signal]]
   (preference-signals/post-feedback! vault-root signal))
 
-(defmethod handle :wikiChat [_ [_ vault-root question trace?]]
-  (wiki/peck! vault-root question (boolean trace?)))
+(defmethod handle :wikiChat [_ [_ vault-root question trace? arena-compare-to]]
+  (wiki/peck! vault-root question (boolean trace?) arena-compare-to))
+
+;; A verdict on an arena A/B pair (kip-app#73) — winner is "a" | "b" | "tie"
+;; | "skip". electron.preference-signals gates on the kip provider and POSTs
+;; to /v1/arena/<id>/verdict; a no-op otherwise.
+(defmethod handle :kipArena [_ [_ vault-root arena-id winner]]
+  (preference-signals/post-arena-verdict! vault-root arena-id winner))
 
 (defmethod handle :wikiChatProgress [_ [_ vault-root]]
   (wiki/peck-progress! vault-root))

--- a/src/electron/electron/preference_signals.cljs
+++ b/src/electron/electron/preference_signals.cljs
@@ -2,13 +2,15 @@
   "In-process bridge to scripts/lib/feedback-poster.js — the electron side of
   the preference-signals epic (kip-app#73). The renderer's content-free
   signals (a 👍/👎 rating, a debounced behaviour event, an arena verdict)
-  come in over the :kipFeedback IPC channel and are POSTed once to the
-  managed Kip backend's /v1/feedback.
+  come in over two IPC channels — :kipFeedback (rating / behaviour) POSTs
+  once to /v1/feedback, :kipArena (a verdict on a regenerate A/B pair) POSTs
+  once to /v1/arena/<id>/verdict.
 
-  feedback-poster.js does the gating itself: postFeedback() checks the
-  active provider is `kip` and resolves { ok: false } without a request
-  otherwise, and it sanitises the signal down to the closed wire field set,
-  so nothing but { call_id, kind, enum/int } can leave. Required via
+  feedback-poster.js does the gating itself: postFeedback() and
+  postArenaVerdict() both check the active provider is `kip` and resolve
+  { ok: false } without a request otherwise, and postFeedback() sanitises
+  the signal down to the closed wire field set, so nothing but
+  { call_id, kind, enum/int } can leave. Required via
   js/require for the same reason electron.llm does (see its docstring)."
   (:require [cljs-bean.core :as bean]
             ["path" :as node-path]
@@ -30,4 +32,17 @@
                      #js {:vaultRoot (or vault-root js/undefined)})
       (p/catch (fn [err]
                  (logger/warn "[PreferenceSignals]" (str "postFeedback failed: " err))
+                 #js {:ok false}))))
+
+(defn post-arena-verdict!
+  "POST a verdict on an arena A/B pair. `winner` is \"a\" | \"b\" | \"tie\" |
+  \"skip\". Never rejects; resolves #js {:ok bool} (false when the provider
+  isn't `kip`, the winner/id is bad, or the request failed)."
+  [vault-root arena-id winner]
+  (-> (.postArenaVerdict feedback-lib
+                         arena-id
+                         winner
+                         #js {:vaultRoot (or vault-root js/undefined)})
+      (p/catch (fn [err]
+                 (logger/warn "[PreferenceSignals]" (str "postArenaVerdict failed: " err))
                  #js {:ok false}))))

--- a/src/electron/electron/wiki.cljs
+++ b/src/electron/electron/wiki.cljs
@@ -364,14 +364,19 @@
 
 (defn peck!
   "Runs the Peck workflow for `question` without filing the answer back.
-  Resolves to {:answer :citedSlugs :candidateSlugs :steps}. `steps` is what
-  the skills tool loop ran (scripts/lib/skills.js), if anything. With `trace?`
-  the run also streams every LLM + skill call, full I/O included, to
-  <coop>/.roost/peck-trace.jsonl."
-  ([vault-root question] (peck! vault-root question false))
-  ([vault-root question trace?]
+  Resolves to {:answer :citedSlugs :candidateSlugs :steps :callId :arenaId}.
+  `steps` is what the skills tool loop ran (scripts/lib/skills.js), if
+  anything. With `trace?` the run also streams every LLM + skill call, full
+  I/O included, to <coop>/.roost/peck-trace.jsonl. `arena-compare-to` (a
+  prior answer's callId) makes this a regenerate free-rider on the managed
+  backend — the answer runs as arena candidate B (kip-app#73)."
+  ([vault-root question] (peck! vault-root question false nil))
+  ([vault-root question trace?] (peck! vault-root question trace? nil))
+  ([vault-root question trace? arena-compare-to]
    (run-node-script! (script "chat.js") vault-root
-                     (cond-> [question] trace? (conj "--trace")))))
+                     (cond-> [question]
+                       trace? (conj "--trace")
+                       (not (string/blank? arena-compare-to)) (conj "--arena-compare-to" arena-compare-to)))))
 
 (defn peck-progress!
   "Reads <coop>/.roost/peck-progress.json, written continuously by chat.js

--- a/src/main/frontend/components/chat.cljs
+++ b/src/main/frontend/components/chat.cljs
@@ -62,7 +62,7 @@
    :pages pages})
 
 (defn- turn->message [result]
-  (let [{:keys [intent answer learned note pages steps callId]} result]
+  (let [{:keys [intent answer learned note pages steps callId arenaId]} result]
     (cond
       (= intent "statement")
       (if learned
@@ -70,7 +70,7 @@
         {:role :assistant :text (if (string/blank? note) "Nothing new to add there." note)})
 
       answer
-      {:role :assistant :text answer :steps steps :call-id callId :answer? true}
+      {:role :assistant :text answer :steps steps :call-id callId :arena-id arenaId :answer? true}
 
       (= intent "reminder")
       {:role :assistant :text "Reminder noted — check the Reminders panel." :steps steps}
@@ -92,19 +92,23 @@
 
 (defn- ask!
   "Run one Peck turn for `question` and hand the turn->message map (plus the
-  originating `:q`) to `on-result`. Shared by a fresh send and a regenerate."
-  [question on-result *loading? *progress *poll-id]
-  (when (and (not (string/blank? question)) (not @*loading?))
-    (reset! *loading? true)
-    (start-poll! *progress *poll-id)
-    (-> (ipc/ipc "wikiChat" (vault-root) question)
-        (p/then (fn [result]
-                  (on-result (assoc (turn->message (bean/->clj result)) :q question))))
-        (p/catch (fn [error]
-                   (swap! *messages conj {:role :error :text (str error)})))
-        (p/finally (fn []
-                     (stop-poll! *progress *poll-id)
-                     (reset! *loading? false))))))
+  originating `:q`) to `on-result`. Shared by a fresh send and a regenerate.
+  `arena-compare-to` (optional): a prior answer's call id — makes this a
+  regenerate free-rider on the managed backend (kip-app#73)."
+  ([question on-result *loading? *progress *poll-id]
+   (ask! question on-result *loading? *progress *poll-id nil))
+  ([question on-result *loading? *progress *poll-id arena-compare-to]
+   (when (and (not (string/blank? question)) (not @*loading?))
+     (reset! *loading? true)
+     (start-poll! *progress *poll-id)
+     (-> (ipc/ipc "wikiChat" (vault-root) question false arena-compare-to)
+         (p/then (fn [result]
+                   (on-result (assoc (turn->message (bean/->clj result)) :q question))))
+         (p/catch (fn [error]
+                    (swap! *messages conj {:role :error :text (str error)})))
+         (p/finally (fn []
+                      (stop-poll! *progress *poll-id)
+                      (reset! *loading? false)))))))
 
 (defn- send-message!
   [*loading? *progress *poll-id]
@@ -117,11 +121,15 @@
 (defn- regenerate!
   "Re-run the question that produced `msg`, appending a fresh answer below it.
   Fires the preference-signals `regenerated` behaviour signal against the old
-  answer's call id — a no-op on every provider but the managed `kip` one."
+  answer's call id. On the managed `kip` connector the re-run also goes
+  through the arena as candidate B (the new answer carries an :arena-id and
+  gets a 'was this better?' strip). A no-op of both on every other provider."
   [{:keys [q call-id]} *loading? *progress *poll-id]
   (when (and (not (string/blank? q)) (not @*loading?))
     (when call-id (pref-signals/behavior! call-id "regenerated"))
-    (ask! q #(swap! *messages conj (assoc % :regen? true)) *loading? *progress *poll-id)))
+    (let [arena-compare-to (when (and call-id (pref-signals/enabled?)) call-id)]
+      (ask! q #(swap! *messages conj (assoc % :regen? true))
+            *loading? *progress *poll-id arena-compare-to))))
 
 (defn- steps-line
   "A ⚙ line per skill the tool loop ran, above the answer."
@@ -169,8 +177,41 @@
      (btn 0 "👎")
      (when (some? @*picked) [:span {:style {:opacity 0.45}} "logged"])]))
 
+;; --- arena verdict (kip-app#73) — shown under a regenerated answer on the
+;; managed backend. A = the previous answer, B = this one. The user can't
+;; tell which model produced which; the backend just wants the winner.
+(rum/defcs verdict-widget < (rum/local nil ::picked)
+  [state arena-id]
+  (let [*picked (::picked state)
+        btn (fn [winner label]
+              (let [active? (= @*picked winner)
+                    dimmed? (and (some? @*picked) (not active?))]
+                [:button
+                 {:key winner
+                  :on-click (fn [] (when (nil? @*picked)
+                                     (reset! *picked winner)
+                                     (pref-signals/verdict! arena-id winner)))
+                  :disabled (some? @*picked)
+                  :style {:font-size "10px" :text-transform "none"
+                          :font-family "ui-monospace, SFMono-Regular, Menlo, monospace"
+                          :line-height "1" :padding "3px 7px"
+                          :border (str "1px solid " (if active? te-orange "var(--ls-border-color)"))
+                          :background (if active? te-orange "transparent")
+                          :opacity (if dimmed? 0.4 1)
+                          :cursor (if (some? @*picked) "default" "pointer")}}
+                 label]))]
+    [:div {:style {:display "flex" :align-items "center" :gap "6px" :margin-top "6px"
+                   :font-size "9px" :letter-spacing "0.1em" :text-transform "uppercase"
+                   :font-family "ui-monospace, SFMono-Regular, Menlo, monospace" :opacity 0.85}}
+     [:span {:style {:opacity 0.5}} "Better?"]
+     (btn "a" "↑ that one")
+     (btn "b" "this one")
+     (btn "tie" "tie")
+     (btn "skip" "skip")
+     (when (some? @*picked) [:span {:style {:opacity 0.45}} "logged"])]))
+
 (rum/defc message-cp
-  [{:keys [role text pages steps call-id answer? regen?] :as msg}
+  [{:keys [role text pages steps call-id arena-id answer? regen?] :as msg}
    {:keys [on-regenerate busy?]}]
   [:div.py-2
    (case role
@@ -202,8 +243,12 @@
          "↻ regenerated"])
       (when (seq steps) (steps-line steps))
       [:div.prose.prose-sm.max-w-none (block/inline-text citation-config :markdown text)]
+      (when (and arena-id (pref-signals/enabled?))
+        (verdict-widget arena-id))
       [:div {:style {:display "flex" :align-items "center" :gap "16px" :flex-wrap "wrap"}}
-       (when (and call-id (pref-signals/enabled?))
+       ;; the A/B verdict is the richer signal — don't also ask for a 👍/👎 on
+       ;; the same answer.
+       (when (and call-id (not arena-id) (pref-signals/enabled?))
          (rate-widget call-id))
        (when (and answer? on-regenerate)
          [:button {:on-click #(when-not busy? (on-regenerate msg))

--- a/src/main/frontend/handler/preference_signals.cljs
+++ b/src/main/frontend/handler/preference_signals.cljs
@@ -10,8 +10,9 @@
 
   `send!` ships one content-free signal to the managed backend via the
   :kipFeedback IPC (electron.preference-signals → scripts/lib/feedback-poster).
-  It's fire-and-forget and best-effort: a disabled gate, a rejected IPC, or a
-  backend error all resolve to nil without disturbing anything."
+  `verdict!` is the same pattern over :kipArena for an arena A/B verdict.
+  All of it is fire-and-forget and best-effort: a disabled gate, a rejected
+  IPC, or a backend error all resolve to nil without disturbing anything."
   (:require [electron.ipc :as ipc]
             [frontend.config :as config]
             [frontend.state :as state]
@@ -51,3 +52,15 @@
   ([call-id behavior edit-bucket]
    (send! (cond-> {:call_id call-id :kind "behavior" :behavior behavior}
             (some? edit-bucket) (assoc :edit_bucket edit-bucket)))))
+
+(def ^:private arena-winners #{"a" "b" "tie" "skip"})
+
+(defn verdict!
+  "Post a verdict on an arena A/B pair (a regenerate free-rider). `winner` is
+  one of \"a\" \"b\" \"tie\" \"skip\". No-op unless `enabled?` and the args
+  are well-formed. Returns a promise that always resolves."
+  [arena-id winner]
+  (if (and (enabled?) (string? arena-id) (seq arena-id) (arena-winners winner))
+    (-> (ipc/ipc "kipArena" (vault-root) arena-id winner)
+        (p/catch (fn [_] nil)))
+    (p/resolved nil)))

--- a/src/test/frontend/handler/preference_signals_test.cljs
+++ b/src/test/frontend/handler/preference_signals_test.cljs
@@ -1,5 +1,6 @@
 (ns frontend.handler.preference-signals-test
   (:require [clojure.test :refer [deftest testing is]]
+            [electron.ipc :as ipc]
             [frontend.handler.preference-signals :as ps]
             [frontend.state :as state]))
 
@@ -43,3 +44,23 @@
       #(do
          (is (some? (ps/send! {:kind "rating"})))          ; no call_id
          (is (some? (ps/send! {:call_id "c1"})))))))       ; no kind
+
+(deftest verdict!-fires-only-for-kip-and-a-valid-winner
+  (let [calls (atom [])]
+    (with-redefs [ipc/ipc (fn [& args] (swap! calls conj args) (js/Promise.resolve nil))]
+      (testing "well-formed verdict on the kip provider hits the :kipArena channel"
+        (reset! calls [])
+        (with-provider "kip" #(ps/verdict! "arena_1" "b"))
+        (is (= 1 (count @calls)))
+        (is (= "kipArena" (ffirst @calls)))
+        (is (= ["arena_1" "b"] (drop 2 (first @calls)))))
+      (testing "no IPC when the gate is closed"
+        (reset! calls [])
+        (with-provider "anthropic" #(ps/verdict! "arena_1" "b"))
+        (is (empty? @calls)))
+      (testing "no IPC for a bad winner or a blank arena id"
+        (reset! calls [])
+        (with-provider "kip"
+          #(do (ps/verdict! "arena_1" "best")
+               (ps/verdict! "" "a")))
+        (is (empty? @calls))))))


### PR DESCRIPTION
The app half of the arena (epic #73). Stacked on #76 (`feat/peck-regenerate`) — GitHub will retarget to `version/file` when #76 merges. Needs **kip PR #22** for the retrieval-layer side.

## Flow

Regenerate a Peck answer on the Kip (managed) backend →
1. the `regenerated` behaviour signal fires (from #76)
2. the re-run goes through `/v1/arena/completions` with `compare_to_call_id` — a **different model** answers
3. the new answer gets a one-tap strip: **Better? · ↑ that one · this one · tie · skip** → `POST /v1/arena/<id>/verdict`

Blind (you can't tell which model is which), one-tap-to-ignore, nothing but the verdict leaves the app. Inert on every other provider.

## Changes

- **`electron.wiki/peck!`** — 4-arity, passes `--arena-compare-to <callId>` to `chat.js`.
- **`handler.cljs`** — `:wikiChat` gains arg 4; new `:kipArena` defmethod → `preference-signals/post-arena-verdict!`.
- **`electron.preference-signals/post-arena-verdict!`** — `js/require`s `feedback-poster.postArenaVerdict`; gated + best-effort.
- **`frontend.handler.preference-signals/verdict!`** — fires `:kipArena` only when `enabled?` and `winner ∈ a|b|tie|skip`.
- **`chat.cljs`** — `turn->message` keeps `:arena-id`; `regenerate!` passes the prior call-id as `arena-compare-to` when on `kip`; `ask!` 6-arity; `verdict-widget`; the 👍/👎 widget is suppressed on an arena message (A/B verdict is the richer signal).

## Verification

`:app` + `:electron` compile clean. Frontend suite **206/206**, 0 failures (+1 `verdict!` gating test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)