### PR TITLE
Calendar: subscribe to an ICS feed from the Reminders panel (kip-app#70)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to the Kip desktop app. The retrieval layer has its own
 changelog at [JWE24-code/kip](https://github.com/JWE24-code/kip/blob/main/CHANGELOG.md).
 
+## [Unreleased]
+
+- **Subscribe to a calendar** — the Reminders panel gains a *Calendar feeds*
+  section: paste a live ICS or `webcal://` URL (Google / Outlook / Fastmail
+  "secret address in iCal format") and Kip pulls your upcoming events in as
+  reminders — each one notified ahead of time with a prep brief drawn from
+  your nest, exactly like a reminder you'd type yourself. Feeds refresh
+  every 20 minutes; the URL is stored like an API key, never in the graph.
+
 ## [0.3.7] — 2026-08-30
 
 - **The deep-groom schedule moved to Coop status** — it's no longer in

--- a/src/electron/electron/calendar.cljs
+++ b/src/electron/electron/calendar.cljs
@@ -1,0 +1,56 @@
+(ns electron.calendar
+  "Calendar-subscription scheduler (kip-app#70). A slow timer (every 20 min,
+  and once ~12s after launch for catch-up) shells scripts/calendar.js sync
+  for every open graph: fetch each subscribed ICS feed, expand the upcoming
+  window, and reconcile it into <coop>/reminders.json as `source: \"calendar\"`
+  rows.
+
+  It does no notifying of its own — the ordinary reminders scheduler
+  (electron.reminders, 60s) fires the calendar-sourced reminders exactly like
+  hand-typed ones. This ns only keeps reminders.json current.
+
+  Same shape as electron.reminders / electron.groom-scheduler: a plain
+  setInterval in the main process; nothing runs while Kip is closed and the
+  next launch's catch-up tick brings the window up to date."
+  (:require [electron.logger :as logger]
+            [electron.state :as state]
+            [electron.wiki :as wiki]
+            [promesa.core :as p]))
+
+(def ^:private log-error (partial logger/error "[Calendar]"))
+
+(defonce ^:private *interval (atom nil))
+
+(def ^:private sync-interval-ms (* 20 60 1000))
+(def ^:private catch-up-delay-ms 12000)
+
+(defn- tick! []
+  (doseq [graph-path (state/get-all-graph-paths)]
+    (when (string? graph-path)
+      (-> (wiki/calendar-sync! graph-path)
+          (p/then (fn [^js result]
+                    (let [r (js->clj result :keywordize-keys true)
+                          {:keys [added updated removed]} (:reconciled r)]
+                      (when (some pos? [(or added 0) (or updated 0) (or removed 0)])
+                        (logger/info "[Calendar]"
+                                     (str graph-path " — reminders +" added " ~" updated " -" removed)))
+                      (doseq [e (:errors r)]
+                        (logger/warn "[Calendar]" (str graph-path " — " e))))))
+          (p/catch (fn [err] (log-error (str "sync failed for " graph-path ": " err))))))))
+
+(defn start-scheduler!
+  "Idempotent — safe to call again on graph switch."
+  []
+  (when @*interval (js/clearInterval @*interval))
+  (js/setTimeout tick! catch-up-delay-ms)
+  (reset! *interval (js/setInterval tick! sync-interval-ms))
+  (logger/info "[Calendar]" "scheduler started (20m)"))
+
+(defn stop-scheduler! []
+  (when @*interval (js/clearInterval @*interval))
+  (reset! *interval nil))
+
+;; A one-shot sync for the settings panel — after adding/removing a feed the
+;; user shouldn't wait 20 min to see events land.
+(defn sync-now! [graph-path]
+  (wiki/calendar-sync! graph-path))

--- a/src/electron/electron/core.cljs
+++ b/src/electron/electron/core.cljs
@@ -20,6 +20,7 @@
             [electron.state :as state]
             [electron.git :as git]
             [electron.reminders :as reminders]
+            [electron.calendar :as calendar]
             [electron.groom-scheduler :as groom-scheduler]
             [electron.window :as win]
             [electron.exceptions :as exceptions]
@@ -300,6 +301,8 @@
                (git/configure-auto-commit!)
 
                (reminders/start-scheduler!)
+
+               (calendar/start-scheduler!)
 
                (groom-scheduler/start-scheduler!)
 

--- a/src/electron/electron/handler.cljs
+++ b/src/electron/electron/handler.cljs
@@ -31,6 +31,7 @@
             [electron.update :as update]
             [electron.updater :as updater]
             [electron.groom-scheduler :as groom-scheduler]
+            [electron.calendar :as calendar]
             [electron.preference-signals :as preference-signals]
             [electron.utils :as utils]
             [electron.wiki :as wiki]
@@ -632,6 +633,24 @@
 
 (defmethod handle :wikiRemindersMute [_ [_ vault-root id on?]]
   (wiki/reminders-mute! vault-root id on?))
+
+;; Calendar subscriptions (kip-app#70) — see electron.calendar + scripts/calendar.js.
+(defmethod handle :calendarList [_ [_ vault-root]]
+  (wiki/calendar-list! vault-root))
+
+(defmethod handle :calendarAdd [_ [_ vault-root url opts]]
+  (-> (wiki/calendar-add! vault-root url (or opts {}))
+      (p/then (fn [r] (calendar/sync-now! vault-root) r))))
+
+(defmethod handle :calendarRemove [_ [_ vault-root id]]
+  (wiki/calendar-remove! vault-root id))
+
+(defmethod handle :calendarToggle [_ [_ vault-root id on?]]
+  (-> (wiki/calendar-toggle! vault-root id on?)
+      (p/then (fn [r] (calendar/sync-now! vault-root) r))))
+
+(defmethod handle :calendarRefresh [_ [_ vault-root]]
+  (calendar/sync-now! vault-root))
 
 (defmethod handle :wikiExportsList [_ [_ vault-root]]
   (wiki/exports-list! vault-root))

--- a/src/electron/electron/wiki.cljs
+++ b/src/electron/electron/wiki.cljs
@@ -422,6 +422,39 @@
   (run-node-script! (script "reminders.js") vault-root [(if on? "unmute" "mute") (str id) "--json"]))
 
 ;; --------------------------------------------------------------------------
+;; Calendar subscriptions (scripts/calendar.js, <coop>/.henhouse/calendars.json).
+;; electron.calendar runs `calendar-sync!` on a slow timer; that keeps
+;; reminders.json current and the normal reminders scheduler does the firing.
+;; The panel uses list/add/remove/toggle/refresh.
+;; --------------------------------------------------------------------------
+
+(defn calendar-sync!
+  "Fetches every enabled ICS feed, expands the upcoming window, and reconciles
+  it into reminders.json (source \"calendar\"). Resolves to
+  {:calendars :ok :events :reconciled {:added :updated :removed} :errors}."
+  [vault-root]
+  (run-node-script! (script "calendar.js") vault-root ["sync" "--json"]))
+
+(defn calendar-list! [vault-root]
+  (run-node-script! (script "calendar.js") vault-root ["list" "--json"]))
+
+(defn calendar-add! [vault-root url {:keys [label lead refresh]}]
+  (run-node-script! (script "calendar.js") vault-root
+                    (cond-> ["add" url "--json"]
+                      (not (string/blank? label)) (conj "--label" label)
+                      (some? lead)                (conj "--lead" (str lead))
+                      (some? refresh)             (conj "--refresh" (str refresh)))))
+
+(defn calendar-remove! [vault-root id]
+  (run-node-script! (script "calendar.js") vault-root ["remove" (str id) "--json"]))
+
+(defn calendar-toggle! [vault-root id on?]
+  (run-node-script! (script "calendar.js") vault-root [(if on? "enable" "disable") (str id) "--json"]))
+
+(defn calendar-refresh! [vault-root]
+  (run-node-script! (script "calendar.js") vault-root ["refresh" "--json"]))
+
+;; --------------------------------------------------------------------------
 ;; <coop>/exports/ — the files Peck's docx/pptx/… skills produce. The Exports
 ;; panel (frontend.components.exports) lists them and drives these actions.
 ;; The renderer only ever sends a bare filename it got from exports-list!;

--- a/src/main/frontend/components/reminders.cljs
+++ b/src/main/frontend/components/reminders.cljs
@@ -17,6 +17,7 @@
             [frontend.config :as config]
             [frontend.state :as state]
             [frontend.ui :as ui]
+            [frontend.util :as util]
             [promesa.core :as p]
             [rum.core :as rum]))
 
@@ -90,6 +91,83 @@
 (defn- set-sound! [id on? refresh]
   (-> (ipc/ipc "wikiRemindersMute" (vault-root) id on?)
       (p/finally refresh)))
+
+;; --- calendar subscriptions (kip-app#70) ---------------------------------
+;; ICS feeds whose upcoming events are reconciled into reminders.json by
+;; electron.calendar. Managed here because a calendar event IS a reminder.
+
+(defn- cal-fetch! [*cals]
+  (-> (ipc/ipc "calendarList" (vault-root))
+      (p/then (fn [r] (reset! *cals (vec (:calendars (bean/->clj r))))))
+      (p/catch (fn [_] (reset! *cals [])))))
+
+(defn- cal-add! [*url *err *cals refresh-reminders]
+  (let [url (string/trim @*url)]
+    (when-not (string/blank? url)
+      (reset! *err nil)
+      (-> (ipc/ipc "calendarAdd" (vault-root) url {})
+          (p/then (fn [r]
+                    (let [{:keys [calendar error]} (bean/->clj r)]
+                      (if (or error (nil? calendar))
+                        (reset! *err (or error "couldn't add that calendar"))
+                        (do (reset! *url "")
+                            (cal-fetch! *cals)
+                            (js/setTimeout refresh-reminders 1500))))))
+          (p/catch (fn [e] (reset! *err (str e))))))))
+
+(defn- cal-remove! [id *cals refresh-reminders]
+  (-> (ipc/ipc "calendarRemove" (vault-root) id)
+      (p/then (fn [_] (cal-fetch! *cals) (refresh-reminders)))))
+
+(defn- cal-refresh! [*cals refresh-reminders]
+  (-> (ipc/ipc "calendarRefresh" (vault-root))
+      (p/finally (fn [] (cal-fetch! *cals) (refresh-reminders)))))
+
+(rum/defcs calendar-feeds < rum/reactive
+  (rum/local nil ::cals)
+  (rum/local "" ::url)
+  (rum/local nil ::err)
+  (rum/local false ::open?)
+  {:will-mount (fn [state] (cal-fetch! (::cals state)) state)}
+  [state refresh-reminders]
+  (let [*cals (::cals state)
+        *url (::url state)
+        *err (::err state)
+        *open? (::open? state)
+        cals (or @*cals [])]
+    [:div.border-t.border-gray-05.mt-2.pt-2.px-1
+     [:button.flex.items-center.gap-1.text-xs.uppercase.tracking-wide.opacity-40.hover:opacity-70
+      {:on-click #(swap! *open? not)}
+      [:span (if @*open? "▾" "▸")] "Calendar feeds"
+      (when (seq cals) [:span.opacity-60 (str " (" (count cals) ")")])]
+     (when @*open?
+       [:div.mt-2.space-y-1
+        (for [c cals]
+          [:div.flex.items-baseline.gap-2.text-xs.group {:key (:id c)}
+           [:div.flex-1.min-w-0
+            [:div.truncate {:class (when (= (:enabled c) false) "opacity-40")} (:label c)]
+            [:div.opacity-45.truncate
+             (cond
+               (:lastError c) [:span.text-red-500 (str "⚠ " (:lastError c))]
+               (:lastFetchedAt c) (str "synced " (when-label (:lastFetchedAt c)))
+               :else "not synced yet")]]
+           (ui/button {:icon "x" :icon-props {:size 12} :variant :ghost :size :xs
+                       :class "opacity-0 group-hover:opacity-100" :title "Remove"
+                       :on-click #(cal-remove! (:id c) *cals refresh-reminders)})])
+        [:div.flex.gap-1.pt-1
+         [:input.form-input.is-small.flex-1.text-xs
+          {:type "text" :placeholder "ICS / webcal:// URL"
+           :value @*url
+           :on-change #(reset! *url (.. % -target -value))
+           :on-key-down (fn [e] (when (= "Enter" (.-key e)) (cal-add! *url *err *cals refresh-reminders)))}]
+         (ui/button {:size :xs :on-click #(cal-add! *url *err *cals refresh-reminders)} "Add")]
+        (when @*err [:div.text-xs.text-red-500.leading-snug @*err])
+        (when (seq cals)
+          [:button.text-xs.opacity-40.hover:opacity-70.pt-1
+           {:on-click #(cal-refresh! *cals refresh-reminders)} "Refresh now"])
+        [:div.text-xs.opacity-35.leading-snug.pt-1
+         "Google / Outlook / Fastmail “secret address in iCal format”. "
+         "Upcoming events become reminders with prep from your nest."]])]))
 
 (rum/defc reminder-row < rum/static
   [{:keys [id title eventAt leadMin status context sound]} refresh]
@@ -166,4 +244,5 @@
          (when (seq recent)
            [:div.mt-3
             [:div.text-xs.uppercase.tracking-wide.opacity-40.px-1.pt-1.pb-1 "Recent"]
-            (for [r recent] (rum/with-key (reminder-row r refresh) (:id r)))])])]]))
+            (for [r recent] (rum/with-key (reminder-row r refresh) (:id r)))])])]
+     (when (util/electron?) (calendar-feeds refresh))]))


### PR DESCRIPTION
**Draft — targeting v0.4.0.** The app half of calendar integration (#70). Pairs with **kip PR #23** (retrieval layer).

An upcoming calendar event *becomes* a reminder (`source: "calendar"`), so it gets the existing nest-retrieval prep brief + lead-time notification for free. No new scheduling / notification code.

## Changes

- **`electron.calendar`** — a 20-min sync scheduler (mirrors `electron.reminders` / `electron.groom-scheduler`): shells `calendar.js sync` per open graph, which fetches each subscribed feed, expands the window, and reconciles into `reminders.json`. `electron.reminders` (60s) then fires the calendar rows like any other.
- **`electron.wiki`** — `calendar-{sync,list,add,remove,toggle,refresh}!`.
- **`handler.cljs`** — `:calendar{List,Add,Remove,Toggle,Refresh}` IPC; Add/Toggle trigger an immediate sync.
- **`frontend.components.reminders`** — a collapsible **Calendar feeds** section: paste an ICS / `webcal://` URL, see per-feed last-sync / errors, remove, "refresh now".

## Verification

`:app` + `:electron` compile clean. Frontend suite **206/206**, 0 failures. (No new frontend test — the section is IPC-driven UI; the ingestion logic is covered in kip #23's `calendar.test.js`.)

## Follow-ups (not this PR)

- Synthetic "Calendar" source type so Peck retrieval can cite an event directly (#70's "events as context sources")
- Per-feed lead-time / label editing in the UI (the CLI + store already support it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)