### PR TITLE
Dropbox: connect an account (v0.4.0 groundwork)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to the Kip desktop app. The retrieval layer has its own
 changelog at [JWE24-code/kip](https://github.com/JWE24-code/kip/blob/main/CHANGELOG.md).
 
+## [Unreleased]
+
+- **Connect a Dropbox account** — Settings → General → Dropbox. A one-tap
+  browser consent (OAuth with PKCE — no password, no secret stored in the
+  app) links a Dropbox account; Kip only ever sees a folder it creates for
+  itself, nothing else in your Dropbox. This is the groundwork for syncing
+  your graph through Dropbox — the sync itself lands in a follow-up.
+
 ## [0.3.7] — 2026-08-30
 
 - **The deep-groom schedule moved to Coop status** — it's no longer in

--- a/src/electron/electron/dropbox.cljs
+++ b/src/electron/electron/dropbox.cljs
@@ -1,0 +1,214 @@
+(ns electron.dropbox
+  "Dropbox account connection for graph sync (kip-app v0.4.0).
+
+  OAuth 2 with PKCE and a loopback redirect — no client secret ships in the
+  app (a distributed desktop app can't keep one). The flow:
+
+    1. make a code_verifier + code_challenge (S256)
+    2. start a one-shot http server on 127.0.0.1:<random port>
+    3. open the system browser at Dropbox's /oauth2/authorize
+    4. Dropbox redirects to http://localhost:<port>/?code=… — the server
+       grabs the code and shows a `close this tab` page
+    5. exchange code + verifier for { access_token, refresh_token } at
+       /oauth2/token, asking for `offline` access so we get a refresh token
+
+  The refresh token is the long-lived secret; it's kept in configs.edn,
+  encrypted with Electron's safeStorage (OS keychain) when that's available,
+  plaintext otherwise (same posture as the LLM keys in .henhouse/llm.json).
+  The short-lived access token lives only in memory.
+
+  This ns is *connection only* — the sync engine that uses the token is
+  separate (electron.dropbox-sync, TODO)."
+  (:require ["crypto" :as crypto]
+            ["http" :as http]
+            ["electron" :refer [shell safeStorage]]
+            [cljs-bean.core :as bean]
+            [clojure.string :as string]
+            [electron.configs :as cfgs]
+            [electron.logger :as logger]
+            [promesa.core :as p]))
+
+;; A PKCE public-client id — embedded in every copy of the app by design,
+;; not a secret. Register `http://localhost` under the app's redirect URIs
+;; in the Dropbox App Console (Dropbox ignores the port for localhost).
+(def ^:private app-key "oqoouohdvzvbdia")
+
+(def ^:private authorize-url "https://www.dropbox.com/oauth2/authorize")
+(def ^:private token-url "https://api.dropboxapi.com/oauth2/token")
+(def ^:private account-url "https://api.dropboxapi.com/2/users/get_current_account")
+
+(def ^:private log-error (partial logger/error "[Dropbox]"))
+
+;; { :access-token str :expires-at ms } — memory only, never persisted
+(defonce ^:private *access (atom nil))
+
+;; ---------------------------------------------------------------------------
+;; refresh-token storage (configs.edn, encrypted when possible)
+;; ---------------------------------------------------------------------------
+
+(defn- encryption-available? []
+  (try (.isEncryptionAvailable safeStorage) (catch :default _ false)))
+
+(defn- protect [^string s]
+  (if (encryption-available?)
+    {:enc (.toString (.encryptString safeStorage s) "base64")}
+    {:plain s}))
+
+(defn- unprotect [{:keys [enc plain]}]
+  (cond
+    plain plain
+    enc (try (.decryptString safeStorage (js/Buffer.from enc "base64"))
+             (catch :default e (log-error (str "decrypt failed: " e)) nil))
+    :else nil))
+
+(defn- load-auth [] (cfgs/get-item :dropbox/auth))
+
+(defn- save-auth! [{:keys [refresh-token account-id]}]
+  (cfgs/set-item! :dropbox/auth
+                  {:refresh (protect refresh-token)
+                   :account-id account-id
+                   :connected-at (js/Date.now)}))
+
+(defn connected? [] (some? (load-auth)))
+
+(defn- refresh-token [] (some-> (load-auth) :refresh unprotect))
+
+;; ---------------------------------------------------------------------------
+;; PKCE + the loopback authorize flow
+;; ---------------------------------------------------------------------------
+
+(defn- b64url [^js buf]
+  (-> (.toString buf "base64")
+      (string/replace "+" "-") (string/replace "/" "_") (string/replace #"=+$" "")))
+
+(defn- make-pkce []
+  (let [verifier (b64url (.randomBytes crypto 64))
+        challenge (b64url (-> (.createHash crypto "sha256") (.update verifier) (.digest)))]
+    {:verifier verifier :challenge challenge}))
+
+(defn- form-encode [m]
+  (->> m
+       (map (fn [[k v]] (str (js/encodeURIComponent (name k)) "=" (js/encodeURIComponent (str v)))))
+       (string/join "&")))
+
+(def ^:private done-page
+  (str "<!doctype html><meta charset=utf-8><title>Kip</title>"
+       "<body style=\"font:15px/1.5 system-ui;margin:16vh auto;max-width:22rem;text-align:center;color:#333\">"
+       "<h2 style=\"font-weight:600\">Dropbox connected</h2>"
+       "<p>You can close this tab and return to Kip.</p></body>"))
+
+(defn- token-request [params]
+  (p/let [^js r (js/fetch token-url
+                          #js {:method "POST"
+                               :headers #js {"Content-Type" "application/x-www-form-urlencoded"}
+                               :body (form-encode (merge {:client_id app-key} params))})
+          j (.json r)]
+    (if (.-ok r)
+      j
+      (let [m (bean/->clj j)]
+        (throw (js/Error. (str "Dropbox token exchange failed (" (.-status r) "): "
+                               (or (:error_description m) (:error m) ""))))))))
+
+(defn- fetch-account [access-token]
+  (-> (js/fetch account-url
+                #js {:method "POST"
+                     :headers #js {"Authorization" (str "Bearer " access-token)
+                                   "Content-Type" "application/json"}
+                     :body "null"})
+      (p/then (fn [^js r] (when (.-ok r) (.json r))))
+      (p/then (fn [j]
+                (when j
+                  (let [m (bean/->clj j)]
+                    {:name (get-in m [:name :display_name])
+                     :email (:email m)}))))
+      (p/catch (fn [_] nil))))
+
+(defn- start-loopback
+  "Resolves { :redirect-uri, :code } — the code arrives on the first request
+   the loopback server sees carrying ?code (or it rejects on ?error/timeout)."
+  []
+  (let [ready (p/deferred)
+        code-d (p/deferred)
+        srv (http/createServer)]
+    (.on srv "request"
+         (fn [^js req ^js res]
+           (let [u (js/URL. (.-url req) "http://localhost")
+                 code (.. u -searchParams (get "code"))
+                 err (.. u -searchParams (get "error"))]
+             (.end (doto res (.writeHead 200 #js {"Content-Type" "text/html"})) done-page)
+             (if code
+               (p/resolve! code-d code)
+               (p/reject! code-d (js/Error. (str "Dropbox authorization "
+                                                (if err (str "was declined (" err ")") "returned no code") "."))))
+             (js/setImmediate #(.close srv)))))
+    (.on srv "error" (fn [e] (p/reject! ready e) (p/reject! code-d e)))
+    (.listen srv 0 "127.0.0.1"
+             (fn [] (p/resolve! ready (str "http://localhost:" (.. srv address -port)))))
+    (js/setTimeout (fn [] (when (p/pending? code-d)
+                            (try (.close srv) (catch :default _ nil))
+                            (p/reject! code-d (js/Error. "Timed out waiting for Dropbox authorization."))))
+                   300000)
+    (p/let [redirect-uri ready]
+      {:redirect-uri redirect-uri :code code-d})))
+
+(defn connect!
+  "Runs the full browser OAuth dance. Resolves { :connected true :account {…} }
+   or rejects with a readable error."
+  []
+  (let [{:keys [verifier challenge]} (make-pkce)]
+    (p/let [{:keys [redirect-uri code]} (start-loopback)
+            _ (.openExternal shell
+                             (str authorize-url "?"
+                                  (form-encode {:client_id app-key
+                                                :response_type "code"
+                                                :code_challenge challenge
+                                                :code_challenge_method "S256"
+                                                :token_access_type "offline"
+                                                :redirect_uri redirect-uri})))
+            auth-code code
+            tok-js (token-request {:grant_type "authorization_code"
+                                   :code auth-code
+                                   :code_verifier verifier
+                                   :redirect_uri redirect-uri})
+            tok (bean/->clj tok-js)
+            account (fetch-account (:access_token tok))]
+      (reset! *access {:access-token (:access_token tok)
+                       :expires-at (+ (js/Date.now) (* 1000 (or (:expires_in tok) 14400)))})
+      (save-auth! {:refresh-token (:refresh_token tok)
+                   :account-id (:account_id tok)})
+      (logger/info "[Dropbox]" (str "connected" (when account (str " as " (:email account)))))
+      {:connected true :account account})))
+
+(defn disconnect! []
+  (reset! *access nil)
+  (cfgs/set-item! :dropbox/auth nil)
+  {:connected false})
+
+(defn access-token
+  "Resolves a currently-valid access token, refreshing via the stored refresh
+   token when needed. Rejects if not connected."
+  []
+  (let [{:keys [access-token expires-at]} @*access]
+    (if (and access-token (> expires-at (+ (js/Date.now) 60000)))
+      (p/resolved access-token)
+      (if-let [rt (refresh-token)]
+        (p/let [tok-js (token-request {:grant_type "refresh_token" :refresh_token rt})
+                tok (bean/->clj tok-js)]
+          (reset! *access {:access-token (:access_token tok)
+                           :expires-at (+ (js/Date.now) (* 1000 (or (:expires_in tok) 14400)))})
+          (:access_token tok))
+        (p/rejected (js/Error. "Not connected to Dropbox."))))))
+
+(defn status
+  "{ :connected bool, :account {:name :email} | nil, :encrypted bool }"
+  []
+  (if-not (connected?)
+    (p/resolved {:connected false})
+    (-> (access-token)
+        (p/then fetch-account)
+        (p/then (fn [account] {:connected true
+                               :account account
+                               :encrypted (encryption-available?)}))
+        (p/catch (fn [e]
+                   {:connected true :account nil
+                    :error (str "Dropbox connection needs re-authorising: " (.-message e))})))))

--- a/src/electron/electron/handler.cljs
+++ b/src/electron/electron/handler.cljs
@@ -31,6 +31,7 @@
             [electron.update :as update]
             [electron.updater :as updater]
             [electron.groom-scheduler :as groom-scheduler]
+            [electron.dropbox :as dropbox]
             [electron.preference-signals :as preference-signals]
             [electron.utils :as utils]
             [electron.wiki :as wiki]
@@ -632,6 +633,18 @@
 
 (defmethod handle :wikiRemindersMute [_ [_ vault-root id on?]]
   (wiki/reminders-mute! vault-root id on?))
+
+;; Dropbox account connection (kip-app v0.4.0) — see electron.dropbox.
+(defmethod handle :dropboxConnect [_ _]
+  (-> (dropbox/connect!)
+      (p/then bean/->js)
+      (p/catch (fn [e] (bean/->js {:connected false :error (or (.-message e) (str e))})))))
+
+(defmethod handle :dropboxDisconnect [_ _]
+  (dropbox/disconnect!))
+
+(defmethod handle :dropboxStatus [_ _]
+  (-> (dropbox/status) (p/then bean/->js)))
 
 (defmethod handle :wikiExportsList [_ [_ vault-root]]
   (wiki/exports-list! vault-root))

--- a/src/main/frontend/components/settings.cljs
+++ b/src/main/frontend/components/settings.cljs
@@ -15,6 +15,7 @@
             [frontend.db :as db]
             [frontend.dicts :as dicts]
             [frontend.handler.config :as config-handler]
+            [frontend.handler.dropbox :as dropbox-handler]
             [frontend.handler.global-config :as global-config-handler]
             [frontend.handler.notification :as notification]
             [frontend.handler.plugin :as plugin-handler]
@@ -463,6 +464,31 @@
          (state/close-settings!)
          (route-handler/redirect! {:to :zotero-setting})))]]])
 
+(rum/defc dropbox-sync-row < rum/reactive
+  {:did-mount (fn [state] (dropbox-handler/refresh!) state)}
+  []
+  (let [{:keys [connected account error]} (state/sub :dropbox/status)
+        connecting? (state/sub :dropbox/connecting?)]
+    [:div.it.sm:grid.sm:grid-cols-3.sm:gap-4.sm:items-center
+     [:label.block.text-sm.font-medium.leading-5.opacity-70 {:for "dropbox_sync"} "Dropbox"]
+     [:div.mt-1.sm:mt-0.sm:col-span-2
+      (if connected
+        [:div
+         [:div.text-sm
+          (if account
+            [:span "Connected as " [:b (or (:name account) (:email account))]]
+            [:span.text-amber-600 (or error "Connected — needs re-authorising")])]
+         [:div.mt-1
+          (ui/button "Disconnect" :class "text-sm" :background "gray"
+                     :on-click #(dropbox-handler/disconnect!))]]
+        [:div
+         (ui/button (if connecting? "Waiting for Dropbox…" "Connect Dropbox")
+                    :class "text-sm" :disabled (boolean connecting?)
+                    :on-click #(dropbox-handler/connect!))
+         [:div.text-sm.opacity-50.mt-1
+          "Opens Dropbox in your browser. Kip syncs your graph to a folder it
+           creates in your Dropbox — nothing else is touched."]])]]))
+
 (defn usage-diagnostics-row [t instrument-disabled?]
   (toggle "usage-diagnostics"
           (t :settings-page/disable-sentry)
@@ -610,6 +636,7 @@
      (theme-modes-row t switch-theme system-theme? dark?)
      (when (and (util/electron?) (not util/mac?)) (native-titlebar-row t))
      (when show-radix-themes? (accent-color-row false))
+     (when (util/electron?) (dropbox-sync-row))
      (when (config/global-config-enabled?) (edit-global-config-edn))
      (when current-repo (edit-config-edn))
      (when current-repo (edit-custom-css))

--- a/src/main/frontend/handler/dropbox.cljs
+++ b/src/main/frontend/handler/dropbox.cljs
@@ -1,0 +1,33 @@
+(ns frontend.handler.dropbox
+  "Renderer side of Dropbox account connection (kip-app v0.4.0). Thin wrappers
+  over the :dropbox* IPC channels (electron.dropbox). The connect flow opens
+  the system browser; the promise resolves once the user finishes (or cancels)
+  the Dropbox consent screen.
+
+  `:dropbox/status` in app-db mirrors the last status read, so components can
+  render reactively without each holding their own copy."
+  (:require [electron.ipc :as ipc]
+            [frontend.state :as state]
+            [frontend.util :as util]
+            [promesa.core :as p]))
+
+(defn- put-status! [s]
+  (state/set-state! :dropbox/status s)
+  s)
+
+(defn refresh! []
+  (when (util/electron?)
+    (-> (ipc/ipc "dropboxStatus")
+        (p/then (fn [r] (put-status! (js->clj r :keywordize-keys true))))
+        (p/catch (fn [_] (put-status! {:connected false}))))))
+
+(defn connect! []
+  (state/set-state! :dropbox/connecting? true)
+  (-> (ipc/ipc "dropboxConnect")
+      (p/then (fn [r] (put-status! (js->clj r :keywordize-keys true))))
+      (p/catch (fn [e] (put-status! {:connected false :error (str e)})))
+      (p/finally (fn [] (state/set-state! :dropbox/connecting? false)))))
+
+(defn disconnect! []
+  (-> (ipc/ipc "dropboxDisconnect")
+      (p/then (fn [r] (put-status! (js->clj r :keywordize-keys true))))))


### PR DESCRIPTION
**Draft — targeting v0.4.0.** Slice 1 of Dropbox sync: **account connection only**. The sync engine is a follow-up.

## Flow

Settings → General → Dropbox → **Connect Dropbox** →
1. `electron.dropbox/connect!` makes a PKCE verifier/challenge, starts a one-shot loopback server on `127.0.0.1:<random port>`, opens the system browser at `dropbox.com/oauth2/authorize`
2. Dropbox redirects to `http://localhost:<port>/?code=…`; the server grabs it, shows a "close this tab" page, exits
3. code + verifier → `/oauth2/token` with `token_access_type=offline` → `{ access_token, refresh_token }`
4. refresh token stored in `configs.edn` (`:dropbox/auth`), **encrypted via Electron `safeStorage`** when the OS keychain is available, plaintext otherwise (same posture as the LLM keys in `.henhouse/llm.json`); access token is memory-only, auto-refreshed

## Decisions baked in

- **App-folder scope** — request `Apps/Kip/` access, not Full Dropbox
- **No client secret** in the app — PKCE public client. The app key `oqoouohdvzvbdia` is a public identifier, embedded by design (cf. rclone)

## Needs before it works end-to-end

Add **`http://localhost`** to the OAuth 2 redirect URIs in the Dropbox App Console for this app key (Dropbox ignores the port for localhost).

## Not in this PR (the sync engine — separate)

`electron.dropbox-sync`: `/files/list_folder` + cursor longpoll for remote changes, `fs_watcher` for local, content-hash reconciliation, LWW-by-mtime / keep-both conflict modes, exclude `.roost/` `.git/` `logseq/.recycle/`. Demote git auto-commit to a local undo history.

## Verification

`:app` + `:electron` compile clean (0 warnings). Frontend suite **206/206**. The OAuth round-trip needs a real browser — no automated test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)