### PR TITLE
Peck: send a short conversation buffer with each turn (kip-app#82)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,14 @@
 All notable changes to the Kip desktop app. The retrieval layer has its own
 changelog at [JWE24-code/kip](https://github.com/JWE24-code/kip/blob/main/CHANGELOG.md).
 
-## [0.3.7] — 2026-08-30
+## [Unreleased]
+
+- **Peck follows a conversation** — ask a follow-up ("expand on that", "and
+  their salary?", "what about the second one?") and Kip now knows what
+  you're referring to. It carries the last few turns into the next
+  question — for finding the right pages *and* for the answer — so you can
+  keep pecking at a topic instead of re-explaining it each time. The buffer
+  is small and lives only for the session.
 
 - **The deep-groom schedule moved to Coop status** — it's no longer in
   Settings → Features. The Coop status panel now reads, top to bottom:

--- a/src/electron/electron/handler.cljs
+++ b/src/electron/electron/handler.cljs
@@ -606,8 +606,8 @@
 (defmethod handle :kipFeedback [_ [_ vault-root signal]]
   (preference-signals/post-feedback! vault-root signal))
 
-(defmethod handle :wikiChat [_ [_ vault-root question trace? arena-compare-to]]
-  (wiki/peck! vault-root question (boolean trace?) arena-compare-to))
+(defmethod handle :wikiChat [_ [_ vault-root question trace? arena-compare-to history]]
+  (wiki/peck! vault-root question (boolean trace?) arena-compare-to history))
 
 ;; A verdict on an arena A/B pair (kip-app#73) — winner is "a" | "b" | "tie"
 ;; | "skip". electron.preference-signals gates on the kip provider and POSTs

--- a/src/electron/electron/wiki.cljs
+++ b/src/electron/electron/wiki.cljs
@@ -370,13 +370,15 @@
   I/O included, to <coop>/.roost/peck-trace.jsonl. `arena-compare-to` (a
   prior answer's callId) makes this a regenerate free-rider on the managed
   backend — the answer runs as arena candidate B (kip-app#73)."
-  ([vault-root question] (peck! vault-root question false nil))
-  ([vault-root question trace?] (peck! vault-root question trace? nil))
-  ([vault-root question trace? arena-compare-to]
+  ([vault-root question] (peck! vault-root question false nil nil))
+  ([vault-root question trace?] (peck! vault-root question trace? nil nil))
+  ([vault-root question trace? arena-compare-to] (peck! vault-root question trace? arena-compare-to nil))
+  ([vault-root question trace? arena-compare-to history]
    (run-node-script! (script "chat.js") vault-root
                      (cond-> [question]
                        trace? (conj "--trace")
-                       (not (string/blank? arena-compare-to)) (conj "--arena-compare-to" arena-compare-to)))))
+                       (not (string/blank? arena-compare-to)) (conj "--arena-compare-to" arena-compare-to)
+                       (seq history) (conj "--history" (js/JSON.stringify (clj->js history)))))))
 
 (defn peck-progress!
   "Reads <coop>/.roost/peck-progress.json, written continuously by chat.js

--- a/src/main/frontend/components/chat.cljs
+++ b/src/main/frontend/components/chat.cljs
@@ -90,46 +90,62 @@
   (reset! *poll-id nil)
   (reset! *progress nil))
 
+;; The last few turns, clipped, sent with the next question so a follow-up
+;; ("expand on that", "and their salary?") can resolve what it refers to
+;; (kip-app#82). Session-only — *messages resets when the conversation clears.
+(def ^:private history-turns 6)
+(def ^:private history-clip 700)
+
+(defn- recent-history [msgs]
+  (->> msgs
+       (filter #(and (#{:user :assistant} (:role %)) (not (string/blank? (:text %)))))
+       (take-last history-turns)
+       (mapv (fn [{:keys [role text]}]
+               {:role (name role)
+                :text (subs text 0 (min (count text) history-clip))}))))
+
 (defn- ask!
   "Run one Peck turn for `question` and hand the turn->message map (plus the
-  originating `:q`) to `on-result`. Shared by a fresh send and a regenerate.
-  `arena-compare-to` (optional): a prior answer's call id — makes this a
-  regenerate free-rider on the managed backend (kip-app#73)."
-  ([question on-result *loading? *progress *poll-id]
-   (ask! question on-result *loading? *progress *poll-id nil))
-  ([question on-result *loading? *progress *poll-id arena-compare-to]
-   (when (and (not (string/blank? question)) (not @*loading?))
-     (reset! *loading? true)
-     (start-poll! *progress *poll-id)
-     (-> (ipc/ipc "wikiChat" (vault-root) question false arena-compare-to)
-         (p/then (fn [result]
-                   (on-result (assoc (turn->message (bean/->clj result)) :q question))))
-         (p/catch (fn [error]
-                    (swap! *messages conj {:role :error :text (str error)})))
-         (p/finally (fn []
-                      (stop-poll! *progress *poll-id)
-                      (reset! *loading? false)))))))
+  originating `:q` and `:history`) to `on-result`. Shared by a fresh send and
+  a regenerate. `opts`: {:arena-compare-to <prior call id, kip-app#73>,
+  :history [{:role :text} …] (kip-app#82)}."
+  [question on-result *loading? *progress *poll-id {:keys [arena-compare-to history]}]
+  (when (and (not (string/blank? question)) (not @*loading?))
+    (reset! *loading? true)
+    (start-poll! *progress *poll-id)
+    (-> (ipc/ipc "wikiChat" (vault-root) question false arena-compare-to (or history []))
+        (p/then (fn [result]
+                  (on-result (assoc (turn->message (bean/->clj result))
+                                    :q question :history (vec history)))))
+        (p/catch (fn [error]
+                   (swap! *messages conj {:role :error :text (str error)})))
+        (p/finally (fn []
+                     (stop-poll! *progress *poll-id)
+                     (reset! *loading? false))))))
 
 (defn- send-message!
   [*loading? *progress *poll-id]
   (let [input (string/trim @*input)]
     (when (and (not (string/blank? input)) (not @*loading?))
-      (reset! *input "")
-      (swap! *messages conj {:role :user :text input})
-      (ask! input #(swap! *messages conj %) *loading? *progress *poll-id))))
+      (let [history (recent-history @*messages)]
+        (reset! *input "")
+        (swap! *messages conj {:role :user :text input})
+        (ask! input #(swap! *messages conj %) *loading? *progress *poll-id {:history history})))))
 
 (defn- regenerate!
   "Re-run the question that produced `msg`, appending a fresh answer below it.
   Fires the preference-signals `regenerated` behaviour signal against the old
   answer's call id. On the managed `kip` connector the re-run also goes
   through the arena as candidate B (the new answer carries an :arena-id and
-  gets a 'was this better?' strip). A no-op of both on every other provider."
-  [{:keys [q call-id]} *loading? *progress *poll-id]
+  gets a 'was this better?' strip). A no-op of both on every other provider.
+  Replays the same conversation history the original turn used."
+  [{:keys [q call-id history]} *loading? *progress *poll-id]
   (when (and (not (string/blank? q)) (not @*loading?))
     (when call-id (pref-signals/behavior! call-id "regenerated"))
     (let [arena-compare-to (when (and call-id (pref-signals/enabled?)) call-id)]
       (ask! q #(swap! *messages conj (assoc % :regen? true))
-            *loading? *progress *poll-id arena-compare-to))))
+            *loading? *progress *poll-id
+            {:arena-compare-to arena-compare-to :history (vec history)}))))
 
 (defn- steps-line
   "A ⚙ line per skill the tool loop ran, above the answer."


### PR DESCRIPTION
**Draft — targeting v0.4.0.** App half of #82. Needs **kip PR #24** for the retrieval-layer side.

## Changes

- **`chat.cljs`** — `recent-history` takes the last 6 user/assistant turns from `*messages` (clipped to 700 chars) and sends them with the next question. `ask!` now takes an opts map `{:arena-compare-to :history}`. The history that was sent is stored on the answer message as `:history`, so a **regenerate replays the same context**.
- **`electron.wiki/peck!`** — a 5-arity + `--history '<json>'` passthrough to `chat.js` (`clj->js` → `JSON.stringify`).
- **`handler.cljs` `:wikiChat`** — arg 6 (`history`) → `peck!`.

Session-only — `*messages` (and so the buffer) resets when the conversation clears.

## Verification

`:app` + `:electron` compile clean (0 warnings). Frontend suite **206/206**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)