### PR TITLE
Dropbox: DIY app-key override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ changelog at [JWE24-code/kip](https://github.com/JWE24-code/kip/blob/main/CHANGE
   wins and Dropbox keeps the older version in its history. Your notes sync;
   the search cache and your API keys stay on the machine. Git's auto-commit
   stays on as a local undo history, no longer a sync mechanism.
+  - *Advanced:* Kip connects through its own registered Dropbox app. If you'd
+    rather use your own (for a separate rate-limit quota), drop your app key
+    in Settings → General → Dropbox → advanced, or set `KIP_DROPBOX_APP_KEY`.
 
 ## [0.3.7] — 2026-08-30
 

--- a/src/electron/electron/dropbox.cljs
+++ b/src/electron/electron/dropbox.cljs
@@ -60,6 +60,12 @@
 (def ^:private token-url "https://api.dropboxapi.com/oauth2/token")
 (def ^:private account-url "https://api.dropboxapi.com/2/users/get_current_account")
 
+;; Request the scopes explicitly so the consent is legible and doesn't silently
+;; depend on which boxes are ticked on the Dropbox app's Permissions tab. The
+;; app (Kip's or a DIY one) must have at least these enabled there.
+(def ^:private oauth-scope
+  "account_info.read files.metadata.read files.content.read files.content.write")
+
 (def ^:private log-error (partial logger/error "[Dropbox]"))
 
 ;; { :access-token str :expires-at ms } — memory only, never persisted
@@ -148,29 +154,40 @@
 
 (defn- start-loopback
   "Resolves { :redirect-uri, :code } — the code arrives on the first request
-   the loopback server sees carrying ?code (or it rejects on ?error/timeout)."
+   the loopback server sees carrying ?code (or it rejects on ?error/timeout).
+   Tracks settlement with a plain flag: promesa 4.0.2 has no `p/pending?` in
+   cljs (its IState protocol is JVM-only), and the timer must be cleared on
+   success so it doesn't fire 5 minutes later."
   []
   (let [ready (p/deferred)
         code-d (p/deferred)
-        srv (http/createServer)]
+        settled (volatile! false)
+        timer (volatile! nil)
+        srv (http/createServer)
+        finish (fn [f] (when-not @settled
+                         (vreset! settled true)
+                         (some-> @timer js/clearTimeout)
+                         (f)))]
     (.on srv "request"
          (fn [^js req ^js res]
            (let [u (js/URL. (.-url req) "http://localhost")
                  code (.. u -searchParams (get "code"))
                  err (.. u -searchParams (get "error"))]
              (.end (doto res (.writeHead 200 #js {"Content-Type" "text/html"})) done-page)
-             (if code
-               (p/resolve! code-d code)
-               (p/reject! code-d (js/Error. (str "Dropbox authorization "
-                                                (if err (str "was declined (" err ")") "returned no code") "."))))
+             (finish #(if code
+                        (p/resolve! code-d code)
+                        (p/reject! code-d (js/Error. (str "Dropbox authorization "
+                                                         (if err (str "was declined (" err ")") "returned no code") ".")))))
              (js/setImmediate #(.close srv)))))
-    (.on srv "error" (fn [e] (p/reject! ready e) (p/reject! code-d e)))
+    (.on srv "error" (fn [e] (p/reject! ready e) (finish #(p/reject! code-d e))))
     (.listen srv 0 "127.0.0.1"
              (fn [] (p/resolve! ready (str "http://localhost:" (.. srv address -port)))))
-    (js/setTimeout (fn [] (when (p/pending? code-d)
-                            (try (.close srv) (catch :default _ nil))
-                            (p/reject! code-d (js/Error. "Timed out waiting for Dropbox authorization."))))
-                   300000)
+    (vreset! timer
+             (js/setTimeout
+              (fn [] (finish (fn []
+                               (try (.close srv) (catch :default _ nil))
+                               (p/reject! code-d (js/Error. "Timed out waiting for Dropbox authorization.")))))
+              300000))
     (p/let [redirect-uri ready]
       {:redirect-uri redirect-uri :code code-d})))
 
@@ -187,6 +204,7 @@
                                                 :code_challenge challenge
                                                 :code_challenge_method "S256"
                                                 :token_access_type "offline"
+                                                :scope oauth-scope
                                                 :redirect_uri redirect-uri})))
             auth-code code
             tok-js (token-request {:grant_type "authorization_code"

--- a/src/electron/electron/dropbox.cljs
+++ b/src/electron/electron/dropbox.cljs
@@ -315,13 +315,22 @@
                                            "Dropbox-API-Arg" (js/JSON.stringify #js {:path remote-path})}})]
     (read-download res)))
 
+(defn get-metadata
+  "Current { :rev :content_hash :size … } for a remote file, or nil if it's gone."
+  [remote-path]
+  (-> (rpc "files/get_metadata" {:path remote-path})
+      (p/catch (fn [e] (if (re-find #"not_found" (str (aget e "dropbox"))) nil (throw e))))))
+
 (defn upload
-  "PUT bytes to `remote-path`. `mode` is :add or a rev string (update). Resolves
-   the new metadata { :rev :size :content_hash … }."
+  "PUT bytes to `remote-path`. `mode` is :add, :overwrite, or a rev string
+   (update). Resolves the new metadata { :rev :size :content_hash … }."
   [remote-path ^js buffer mode]
   (p/let [token (access-token)
           arg {:path remote-path
-               :mode (if (string? mode) {".tag" "update" :update mode} {".tag" "add"})
+               :mode (cond
+                       (string? mode) {".tag" "update" :update mode}
+                       (= mode :overwrite) {".tag" "overwrite"}
+                       :else {".tag" "add"})
                :autorename false
                :mute true}
           ^js res (js/fetch (str content-base "files/upload")

--- a/src/electron/electron/dropbox.cljs
+++ b/src/electron/electron/dropbox.cljs
@@ -272,12 +272,15 @@
 (def ^:private api-base "https://api.dropboxapi.com/2/")
 (def ^:private content-base "https://content.dropboxapi.com/2/")
 
-(defn- api-error [status body]
+(defn- api-error [status url body]
   (let [m (try (bean/->clj (js/JSON.parse body)) (catch :default _ nil))
-        summary (:error_summary m)]
-    (doto (js/Error. (str "Dropbox API " status (when summary (str ": " summary))))
+        ;; JSON errors carry error_summary; request-level 400s are plain text
+        detail (or (:error_summary m)
+                   (some-> body string/trim not-empty (subs 0 (min 300 (count (string/trim body))))))
+        endpoint (last (string/split (str url) #"/"))]
+    (doto (js/Error. (str "Dropbox API " status " on " endpoint (when detail (str ": " detail))))
       (aset "status" status)
-      (aset "dropbox" (or summary body)))))
+      (aset "dropbox" (or detail body)))))
 
 (defn rpc
   "POST {api-base}<endpoint> with a JSON body, JSON back. `arg` is a CLJS map."
@@ -291,7 +294,7 @@
           text (.text res)]
     (if (.-ok res)
       (if (seq text) (bean/->clj (js/JSON.parse text)) {})
-      (throw (api-error (.-status res) text)))))
+      (throw (api-error (.-status res) (.-url res) text)))))
 
 (defn- read-download [^js res]
   (if (.-ok res)
@@ -300,7 +303,7 @@
             m (bean/->clj (js/JSON.parse hdr))]
       {:buffer (js/Buffer.from ab) :rev (:rev m) :size (:size m)})
     (-> (.text res)
-        (p/then (fn [t] (throw (api-error (.-status res) t)))))))
+        (p/then (fn [t] (throw (api-error (.-status res) (.-url res) t)))))))
 
 (defn download
   "GET a file's bytes. Resolves { :buffer <Buffer> :rev str :size n }."
@@ -330,7 +333,7 @@
           text (.text res)]
     (if (.-ok res)
       (bean/->clj (js/JSON.parse text))
-      (throw (api-error (.-status res) text)))))
+      (throw (api-error (.-status res) (.-url res) text)))))
 
 (defn delete! [remote-path]
   (-> (rpc "files/delete_v2" {:path remote-path})
@@ -364,4 +367,4 @@
      (if (.-ok res)
        (let [m (bean/->clj (js/JSON.parse text))]
          {:changes (:changes m) :backoff (:backoff m)})
-       (throw (api-error (.-status res) text))))))
+       (throw (api-error (.-status res) (.-url res) text))))))

--- a/src/electron/electron/dropbox.cljs
+++ b/src/electron/electron/dropbox.cljs
@@ -17,8 +17,13 @@
   plaintext otherwise (same posture as the LLM keys in .henhouse/llm.json).
   The short-lived access token lives only in memory.
 
-  This ns is *connection only* — the sync engine that uses the token is
-  separate (electron.dropbox-sync, TODO)."
+  App key: Kip ships its own (`default-app-key`). A DIY user can override it
+  with their own Dropbox app — KIP_DROPBOX_APP_KEY or the advanced setting —
+  e.g. to get their own rate-limit quota. Planned: a *managed* mode where a
+  Kip-subscription account brokers the OAuth through api.kip-ai.be so the
+  user needs no Dropbox app of their own (backend endpoints TBD).
+
+  This ns is *connection only*; the sync engine is electron.dropbox-sync."
   (:require ["crypto" :as crypto]
             ["http" :as http]
             ["electron" :refer [shell safeStorage]]
@@ -28,10 +33,28 @@
             [electron.logger :as logger]
             [promesa.core :as p]))
 
-;; A PKCE public-client id — embedded in every copy of the app by design,
-;; not a secret. Register `http://localhost` under the app's redirect URIs
-;; in the Dropbox App Console (Dropbox ignores the port for localhost).
-(def ^:private app-key "oqoouohdvzvbdia")
+;; Kip's own Dropbox PKCE public-client id — embedded in every copy of the app
+;; by design, not a secret (a PKCE public client has no client secret). One
+;; value for every install; Dropbox rate-limits per *app*, so a DIY user who
+;; wants their own quota (or their own Dropbox app for any reason) can override
+;; it — KIP_DROPBOX_APP_KEY, or :dropbox/config {:app-key "…"} in configs.edn
+;; (Settings → General → Dropbox → advanced). Whatever app is used must have
+;; `http://localhost` registered as an OAuth redirect URI.
+(def ^:private default-app-key "oqoouohdvzvbdia")
+
+(defn app-key []
+  (or (not-empty (aget (.-env js/process) "KIP_DROPBOX_APP_KEY"))
+      (not-empty (:app-key (cfgs/get-item :dropbox/config)))
+      default-app-key))
+
+(defn using-custom-app-key? [] (not= (app-key) default-app-key))
+
+(defn set-app-key!
+  "Persist a DIY Dropbox app key (or clear it with nil/blank). Disconnects
+   first — tokens from one app aren't valid for another."
+  [k]
+  (let [k (some-> k str string/trim not-empty)]
+    (cfgs/set-item! :dropbox/config (if k {:app-key k} nil))))
 
 (def ^:private authorize-url "https://www.dropbox.com/oauth2/authorize")
 (def ^:private token-url "https://api.dropboxapi.com/oauth2/token")
@@ -101,7 +124,7 @@
   (p/let [^js r (js/fetch token-url
                           #js {:method "POST"
                                :headers #js {"Content-Type" "application/x-www-form-urlencoded"}
-                               :body (form-encode (merge {:client_id app-key} params))})
+                               :body (form-encode (merge {:client_id (app-key)} params))})
           j (.json r)]
     (if (.-ok r)
       j
@@ -159,7 +182,7 @@
     (p/let [{:keys [redirect-uri code]} (start-loopback)
             _ (.openExternal shell
                              (str authorize-url "?"
-                                  (form-encode {:client_id app-key
+                                  (form-encode {:client_id (app-key)
                                                 :response_type "code"
                                                 :code_challenge challenge
                                                 :code_challenge_method "S256"
@@ -184,6 +207,14 @@
   (cfgs/set-item! :dropbox/auth nil)
   {:connected false})
 
+(defn set-app-key-and-disconnect!
+  "Swap the DIY Dropbox app key and drop any existing connection (tokens from
+   one app don't work for another). Pass nil/blank to go back to Kip's key."
+  [k]
+  (set-app-key! k)
+  (disconnect!)
+  {:connected false :customAppKey (using-custom-app-key?)})
+
 (defn access-token
   "Resolves a currently-valid access token, refreshing via the stored refresh
    token when needed. Rejects if not connected."
@@ -200,18 +231,20 @@
         (p/rejected (js/Error. "Not connected to Dropbox."))))))
 
 (defn status
-  "{ :connected bool, :account {:name :email} | nil, :encrypted bool }"
+  "{ :connected bool, :account {:name :email} | nil, :encrypted bool,
+     :customAppKey bool }"
   []
-  (if-not (connected?)
-    (p/resolved {:connected false})
-    (-> (access-token)
-        (p/then fetch-account)
-        (p/then (fn [account] {:connected true
-                               :account account
-                               :encrypted (encryption-available?)}))
-        (p/catch (fn [e]
-                   {:connected true :account nil
-                    :error (str "Dropbox connection needs re-authorising: " (.-message e))})))))
+  (let [base {:customAppKey (using-custom-app-key?)}]
+    (if-not (connected?)
+      (p/resolved (assoc base :connected false))
+      (-> (access-token)
+          (p/then fetch-account)
+          (p/then (fn [account] (assoc base :connected true
+                                       :account account
+                                       :encrypted (encryption-available?))))
+          (p/catch (fn [e]
+                     (assoc base :connected true :account nil
+                            :error (str "Dropbox connection needs re-authorising: " (.-message e)))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Files API — the low-level calls the sync engine builds on

--- a/src/electron/electron/dropbox_sync.cljs
+++ b/src/electron/electron/dropbox_sync.cljs
@@ -353,9 +353,11 @@
    longpoll. `conflict-mode` ∈ auto|manual. A failure is logged and any
    partially-written state is torn down so a retry starts clean."
   [graph-path opts]
+  (log (str "enable! " graph-path " -> " (graph-remote-name graph-path)))
   (-> (do-enable! graph-path opts)
       (p/catch (fn [e]
-                 (log-error (str "enable! failed for " graph-path ": " (.-message e)
+                 (log-error (str "enable! failed for " graph-path
+                                 " (remote " (graph-remote-name graph-path) "): " (.-message e)
                                  (when-let [d (aget e "dropbox")] (str " — " d))))
                  (try (fs/rmSync (state-path graph-path)) (catch :default _ nil))
                  (swap! *runtime dissoc graph-path)

--- a/src/electron/electron/dropbox_sync.cljs
+++ b/src/electron/electron/dropbox_sync.cljs
@@ -298,11 +298,7 @@
             (p/recur next-page acc'))
           {:files acc' :cursor (:cursor page)})))))
 
-(defn enable!
-  "Turn on sync for `graph-path`. Ensures /<name> in the app folder, reconciles
-   local ↔ remote by content hash (uploads what's missing/changed, records what
-   already matches, pulls remote-only files down), records a cursor, and starts
-   the watcher + longpoll. `conflict-mode` ∈ auto|manual."
+(defn- do-enable!
   [graph-path {:keys [conflict-mode] :or {conflict-mode "auto"}}]
   (if (synced? graph-path)
     (p/resolved {:synced true})
@@ -350,6 +346,20 @@
       (log (str "sync enabled: " graph-path " -> " remote " (" (count locals) " local, "
                 (count remote-files) " remote)"))
       {:synced true :remote remote :files (count (:files (read-state graph-path)))})))
+
+(defn enable!
+  "Turn on sync for `graph-path`. Ensures /<name> in the app folder, reconciles
+   local ↔ remote by content hash, records a cursor, starts the watcher +
+   longpoll. `conflict-mode` ∈ auto|manual. A failure is logged and any
+   partially-written state is torn down so a retry starts clean."
+  [graph-path opts]
+  (-> (do-enable! graph-path opts)
+      (p/catch (fn [e]
+                 (log-error (str "enable! failed for " graph-path ": " (.-message e)
+                                 (when-let [d (aget e "dropbox")] (str " — " d))))
+                 (try (fs/rmSync (state-path graph-path)) (catch :default _ nil))
+                 (swap! *runtime dissoc graph-path)
+                 (throw e)))))
 
 (defn disable! [graph-path]
   (when-let [stop (get-in @*runtime [graph-path :loop-stop])] (stop))

--- a/src/electron/electron/dropbox_sync.cljs
+++ b/src/electron/electron/dropbox_sync.cljs
@@ -50,6 +50,21 @@
     (swap! *locks assoc graph-path (p/catch run (fn [_] nil)))
     run))
 
+;; abs-path -> content-hash we just wrote from a pull. The chokidar watcher
+;; checks this: if the file on disk is exactly what a pull put there, that
+;; `change` event is our own echo — drop it instead of pushing it back. TTL'd
+;; so a genuine later edit of the same file isn't muted.
+(defonce ^:private *pull-writes (atom {}))
+(def ^:private pull-write-ttl-ms 20000)
+
+(defn- note-pull-write! [abs hash]
+  (swap! *pull-writes assoc abs hash)
+  (js/setTimeout #(swap! *pull-writes (fn [m] (if (= (get m abs) hash) (dissoc m abs) m)))
+                 pull-write-ttl-ms))
+
+(defn- own-echo? [abs current-hash]
+  (= current-hash (get @*pull-writes abs)))
+
 ;; ---------------------------------------------------------------------------
 ;; per-graph state file
 ;; ---------------------------------------------------------------------------
@@ -140,22 +155,30 @@
       (p/let [^js buf (.readFileSync fs abs)
               hash (dropbox-content-hash buf)
               recorded (get-in st [:files rel])]
-        (when (or (nil? recorded) (not= (:hash recorded) hash))
+        (when (and (or (nil? recorded) (not= (:hash recorded) hash))
+                   (not (own-echo? abs hash)))          ; don't push a pull's own write
           (if (> (.-length buf) max-file-bytes)
             (log (str "skipping " rel " — larger than the sync limit"))
-            (p/let [known-rev (:rev recorded)
-                    meta (-> (dbx/upload (remote-path graph-path rel) buf (or known-rev :add))
-                             (p/catch (fn [e]
-                                        ;; someone changed it upstream first — pull will
-                                        ;; sort it out; re-add without a rev so we don't lose it
-                                        (if (re-find #"conflict" (str (aget e "dropbox")))
-                                          (dbx/upload (str (remote-path graph-path rel)
-                                                           " (Kip " (subs (.toISOString (js/Date.)) 0 10) ")")
-                                                      buf :add)
-                                          (throw e)))))]
+            (p/let [rpath (remote-path graph-path rel)
+                    meta (-> (dbx/upload rpath buf (or (:rev recorded) :add))
+                             (p/catch
+                              (fn [e]
+                                (if-not (re-find #"conflict" (str (aget e "dropbox")))
+                                  (throw e)
+                                  ;; the known rev is stale. Check what's actually there:
+                                  (p/let [rm (dbx/get-metadata rpath)]
+                                    (cond
+                                      ;; remote already holds our bytes — our own earlier
+                                      ;; push; nothing to do but record the current rev
+                                      (= (:content_hash rm) hash) rm
+                                      ;; genuine divergence — local wins (auto policy),
+                                      ;; overwrite; Dropbox keeps the old version
+                                      :else (p/do!
+                                             (log (str "push conflict — local " rel " overwrote the remote"))
+                                             (dbx/upload rpath buf :overwrite))))))))]
               (write-state! graph-path
                             (assoc-in (read-state graph-path) [:files rel]
-                                      {:rev (:rev meta) :hash (:content_hash meta)}))
+                                      {:rev (:rev meta) :hash (or (:content_hash meta) hash)}))
               (log (str "pushed " rel)))))))))
 
 (defn- flush-pending! [graph-path]
@@ -201,27 +224,38 @@
               (p/resolved (update st :files dissoc rel)))))
 
       (= tag "file")
-      (let [recorded (get-in st [:files rel])]
-        (if (= (:rev recorded) (:rev entry))
+      (let [recorded (get-in st [:files rel])
+            abs (abs-path graph-path rel)
+            local-now (when (fs/existsSync abs) (local-hash abs))]
+        (cond
+          ;; already reconciled against this exact revision
+          (= (:rev recorded) (:rev entry))
           (p/resolved st)
-          (p/let [abs (abs-path graph-path rel)
-                  local-changed? (and (fs/existsSync abs) recorded
-                                      (not= (:hash recorded) (local-hash abs)))
-                  dl (dbx/download (:path_display entry))]
+
+          ;; the bytes on disk already ARE this entry's content — our own push
+          ;; coming back, or a race we already handled. Catch the rev up, don't
+          ;; rewrite the file (that would re-trigger the watcher).
+          (and local-now (= local-now (:content_hash entry)))
+          (p/resolved (assoc-in st [:files rel] {:rev (:rev entry) :hash local-now}))
+
+          :else
+          (p/let [local-changed? (and local-now recorded (not= (:hash recorded) local-now))
+                  dl (dbx/download (:path_display entry))
+                  dl-hash (dropbox-content-hash (:buffer dl))]
             (fs/mkdirSync (node-path/dirname abs) #js {:recursive true})
             (if (and local-changed? (= "manual" (:conflictMode st)))
-              (let [cn (conflict-name rel (subs (.toISOString (js/Date.)) 0 10))]
-                (fs/writeFileSync (abs-path graph-path cn) (:buffer dl))
+              (let [cn (conflict-name rel (subs (.toISOString (js/Date.)) 0 10))
+                    cabs (abs-path graph-path cn)]
+                (note-pull-write! cabs dl-hash)
+                (fs/writeFileSync cabs (:buffer dl))
                 (log (str "conflict — wrote " cn))
                 (p/resolved st))
               (do
-                ;; auto (or no local change): the remote copy wins
-                (when (and local-changed?)
+                (when local-changed?
                   (log (str "conflict — Dropbox copy of " rel " won")))
+                (note-pull-write! abs dl-hash)
                 (fs/writeFileSync abs (:buffer dl))
-                (p/resolved (assoc-in st [:files rel]
-                                      {:rev (:rev dl)
-                                       :hash (dropbox-content-hash (:buffer dl))})))))))
+                (p/resolved (assoc-in st [:files rel] {:rev (:rev dl) :hash dl-hash})))))))
 
       :else (p/resolved st))))
 
@@ -264,9 +298,13 @@
                        :awaitWriteFinish true
                        :persistent true})
         on (fn [pth]
-             (let [rel (-> (node-path/relative graph-path pth) (string/replace "\\" "/"))]
+             (let [rel (-> (node-path/relative graph-path pth) (string/replace "\\" "/"))
+                   abs (abs-path graph-path rel)]
                (when (and (seq rel) (not (excluded? rel)))
-                 (schedule-push! graph-path rel))))]
+                 (if (and (fs/existsSync abs) (own-echo? abs (local-hash abs)))
+                   ;; this is a file a pull just wrote — consume the marker, don't push
+                   (swap! *pull-writes dissoc abs)
+                   (schedule-push! graph-path rel)))))]
     (doto w
       (.on "add" on) (.on "change" on) (.on "unlink" on))
     (swap! *runtime assoc-in [graph-path :watcher] w)))

--- a/src/electron/electron/handler.cljs
+++ b/src/electron/electron/handler.cljs
@@ -654,10 +654,15 @@
 (defmethod handle :dropboxSyncStatus [_ [_ graph-path]]
   (bean/->js (dropbox-sync/status graph-path)))
 
+(defn- dropbox-sync-error [e fallback-map]
+  (logger/error "[DropboxSync]" (str "IPC failure: " (.-message e)
+                                     (when-let [d (aget e "dropbox")] (str " — " d))))
+  (bean/->js (assoc fallback-map :error (or (.-message e) (str e)))))
+
 (defmethod handle :dropboxSyncEnable [_ [_ graph-path opts]]
   (-> (dropbox-sync/enable! graph-path (or opts {}))
       (p/then bean/->js)
-      (p/catch (fn [e] (bean/->js {:synced false :error (or (.-message e) (str e))})))))
+      (p/catch #(dropbox-sync-error % {:synced false}))))
 
 (defmethod handle :dropboxSyncDisable [_ [_ graph-path]]
   (bean/->js (dropbox-sync/disable! graph-path)))
@@ -665,7 +670,7 @@
 (defmethod handle :dropboxSyncNow [_ [_ graph-path]]
   (-> (dropbox-sync/sync-now! graph-path)
       (p/then bean/->js)
-      (p/catch (fn [e] (bean/->js {:synced true :error (or (.-message e) (str e))})))))
+      (p/catch #(dropbox-sync-error % {:synced true}))))
 
 (defmethod handle :wikiExportsList [_ [_ vault-root]]
   (wiki/exports-list! vault-root))

--- a/src/electron/electron/handler.cljs
+++ b/src/electron/electron/handler.cljs
@@ -647,6 +647,9 @@
 (defmethod handle :dropboxStatus [_ _]
   (-> (dropbox/status) (p/then bean/->js)))
 
+(defmethod handle :dropboxSetAppKey [_ [_ k]]
+  (bean/->js (dropbox/set-app-key-and-disconnect! k)))
+
 ;; Dropbox graph sync (kip-app v0.4.0) — see electron.dropbox-sync.
 (defmethod handle :dropboxSyncStatus [_ [_ graph-path]]
   (bean/->js (dropbox-sync/status graph-path)))

--- a/src/main/frontend/components/settings.cljs
+++ b/src/main/frontend/components/settings.cljs
@@ -464,13 +464,38 @@
          (state/close-settings!)
          (route-handler/redirect! {:to :zotero-setting})))]]])
 
+(rum/defcs dropbox-app-key-advanced < rum/reactive (rum/local false ::open?) (rum/local "" ::val)
+  [state custom?]
+  (let [*open? (::open? state) *val (::val state)]
+    [:div.mt-2
+     [:button.text-xs.opacity-40.hover:opacity-70 {:on-click #(swap! *open? not)}
+      (str (if @*open? "▾" "▸") " advanced")]
+     (when @*open?
+       [:div.mt-1.text-xs.opacity-70.leading-snug
+        (if custom?
+          [:div
+           "Using your own Dropbox app. "
+           [:a.text-blue-500 {:on-click #(dropbox-handler/set-app-key! nil)} "Switch back to Kip's"]]
+          [:div.flex.flex-col.gap-1 {:style {:max-width "24rem"}}
+           [:span "Use your own Dropbox app key (for your own rate-limit quota). "
+            "Register an app at dropbox.com/developers, scoped access, with "
+            [:code "http://localhost"] " as a redirect URI."]
+           [:div.flex.gap-1
+            [:input.form-input.is-small.flex-1 {:type "text" :placeholder "app key"
+                                                :value @*val
+                                                :on-change #(reset! *val (.. % -target -value))}]
+            (ui/button "Use" :class "text-xs"
+                       :on-click #(when (seq (string/trim @*val))
+                                    (dropbox-handler/set-app-key! (string/trim @*val))
+                                    (reset! *val "")))]])])]))
+
 (rum/defc dropbox-sync-row < rum/reactive
   {:did-mount (fn [state]
                 (dropbox-handler/refresh!)
                 (dropbox-handler/refresh-sync!)
                 state)}
   [current-repo]
-  (let [{:keys [connected account error]} (state/sub :dropbox/status)
+  (let [{:keys [connected account error customAppKey]} (state/sub :dropbox/status)
         connecting? (state/sub :dropbox/connecting?)
         {:keys [synced conflictMode files lastSync] :as sync} (state/sub :dropbox/sync)
         sync-busy? (state/sub :dropbox/sync-busy?)]
@@ -484,7 +509,8 @@
                     :on-click #(dropbox-handler/connect!))
          [:div.text-sm.opacity-50.mt-1
           "Opens Dropbox in your browser. Kip only ever sees a folder it
-           creates for itself (Apps/Kip-ai/) — nothing else in your Dropbox."]]
+           creates for itself (Apps/Kip-ai/) — nothing else in your Dropbox."]
+         (dropbox-app-key-advanced (boolean customAppKey))]
         [:div
          [:div.text-sm
           (if account

--- a/src/main/frontend/components/settings.cljs
+++ b/src/main/frontend/components/settings.cljs
@@ -538,6 +538,8 @@
                (ui/button (if sync-busy? "Setting up…" "Sync this graph with Dropbox")
                           :class "text-sm" :disabled (boolean sync-busy?)
                           :on-click #(dropbox-handler/enable-sync! "auto"))
+               (when (:error sync)
+                 [:div.text-xs.text-red-500.mt-1.leading-snug (str "Couldn't start sync: " (:error sync))])
                [:div.text-xs.opacity-50.mt-1
                 "Two-way. Newest change wins on a conflict (Dropbox keeps history).
                  Notes only — the search cache and your API keys stay on this machine."]])])])]]))

--- a/src/main/frontend/handler/dropbox.cljs
+++ b/src/main/frontend/handler/dropbox.cljs
@@ -8,6 +8,7 @@
   render reactively without each holding their own copy."
   (:require [electron.ipc :as ipc]
             [frontend.config :as config]
+            [frontend.handler.notification :as notification]
             [frontend.state :as state]
             [frontend.util :as util]
             [promesa.core :as p]))
@@ -44,19 +45,32 @@
 
 (defn- graph-dir [] (config/get-repo-dir (state/get-current-repo)))
 
-(defn- put-sync! [s] (state/set-state! :dropbox/sync (js->clj s :keywordize-keys true)) s)
+(defn- put-sync! [s]
+  (let [m (js->clj s :keywordize-keys true)]
+    (state/set-state! :dropbox/sync m)
+    (when-let [err (:error m)]
+      (notification/show! (str "Dropbox sync: " err) :error))
+    m))
 
 (defn refresh-sync! []
   (when (and (util/electron?) (graph-dir))
     (-> (ipc/ipc "dropboxSyncStatus" (graph-dir))
-        (p/then put-sync!)
-        (p/catch (fn [_] (put-sync! #js {:synced false}))))))
+        (p/then (fn [r]
+                  ;; a status read carries no error — don't stomp an error the
+                  ;; last enable!/sync-now! surfaced
+                  (let [prev (:dropbox/sync @state/state)
+                        m (js->clj r :keywordize-keys true)]
+                    (state/set-state! :dropbox/sync
+                                      (cond-> m
+                                        (and (:error prev) (not (:synced m))) (assoc :error (:error prev)))))))
+        (p/catch (fn [_] nil)))))
 
 (defn enable-sync! [conflict-mode]
   (state/set-state! :dropbox/sync-busy? true)
   (-> (ipc/ipc "dropboxSyncEnable" (graph-dir) {:conflict-mode (or conflict-mode "auto")})
       (p/then put-sync!)
-      (p/finally (fn [] (state/set-state! :dropbox/sync-busy? false) (refresh-sync!)))))
+      (p/then (fn [m] (when (:synced m) (refresh-sync!))))
+      (p/finally (fn [] (state/set-state! :dropbox/sync-busy? false)))))
 
 (defn disable-sync! []
   (-> (ipc/ipc "dropboxSyncDisable" (graph-dir))
@@ -66,4 +80,5 @@
   (state/set-state! :dropbox/sync-busy? true)
   (-> (ipc/ipc "dropboxSyncNow" (graph-dir))
       (p/then put-sync!)
-      (p/finally (fn [] (state/set-state! :dropbox/sync-busy? false) (refresh-sync!)))))
+      (p/then (fn [_] (refresh-sync!)))
+      (p/finally (fn [] (state/set-state! :dropbox/sync-busy? false)))))

--- a/src/main/frontend/handler/dropbox.cljs
+++ b/src/main/frontend/handler/dropbox.cljs
@@ -33,6 +33,13 @@
   (-> (ipc/ipc "dropboxDisconnect")
       (p/then (fn [r] (put-status! (js->clj r :keywordize-keys true))))))
 
+(defn set-app-key!
+  "DIY: point Kip at your own Dropbox app (nil/blank → back to Kip's).
+  Disconnects, since tokens don't carry between apps."
+  [k]
+  (-> (ipc/ipc "dropboxSetAppKey" (or k ""))
+      (p/then (fn [_] (refresh!)))))
+
 ;; --- per-graph sync -------------------------------------------------------
 
 (defn- graph-dir [] (config/get-repo-dir (state/get-current-repo)))


### PR DESCRIPTION
**Draft — targeting v0.4.0. Stacked on #83** (which is stacked on #80). Retargets up the chain as they merge.

Kip's Dropbox rate limit is **per app, not per user** — if Kip gets a lot of syncing users they all share one ceiling. This adds an escape hatch: bring your own Dropbox app.

## Changes

- **`electron.dropbox`** — `app-key` is now a function:
  1. `KIP_DROPBOX_APP_KEY` env var
  2. `:dropbox/config {:app-key "…"}` in `configs.edn`
  3. Kip's bundled `default-app-key`

  `set-app-key-and-disconnect!` (tokens don't carry between apps), `using-custom-app-key?`, and `status` now reports `:customAppKey`.
- **`handler.cljs`** `:dropboxSetAppKey` · **`frontend.handler.dropbox`** `set-app-key!`
- **Settings** — an "advanced" disclosure in the Dropbox row: paste your own key (with the "register an app, `http://localhost` redirect URI" note), or switch back to Kip's.

## The other half — managed mode

Filed as **#85**: a *managed* mode where a Kip-subscription account brokers the OAuth through `api.kip-ai.be` (no Dropbox app of your own). Blocked on the backend endpoints (private repo) — design + client seam in the issue.

## Verification

`:app` + `:electron` compile clean (0 warnings). Frontend suite **206/206**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)