### PR TITLE
Peck: render the answer as it streams in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to the Kip desktop app. The retrieval layer has its own
 changelog at [JWE24-code/kip](https://github.com/JWE24-code/kip/blob/main/CHANGELOG.md).
 
+## [Unreleased]
+
+- **The answer streams in** — a Peck answer now appears word by word as the
+  model writes it, instead of after a wait then all at once. Works on the
+  Anthropic and OpenAI-compatible (OpenAI / DeepSeek / local / custom)
+  providers; the managed Kip backend still returns the answer in one piece
+  for now. Pairs with the retrieval-layer speedups (skip the key-term pass
+  when the direct search is already confident; skip the skills tool-loop
+  when the nest can answer on its own).
+
 ## [0.4.0] — 2026-08-31
 
 - **Subscribe to a calendar** — the Reminders panel gains a *Calendar feeds*

--- a/src/main/frontend/components/chat.cljs
+++ b/src/main/frontend/components/chat.cljs
@@ -32,7 +32,10 @@
             [rum.core :as rum]
             [logseq.shui.ui :as ui]))
 
-(def ^:private poll-ms 1000)
+;; Polled while a turn runs: the ⚙ activity feed and the streaming answer
+;; (`:partialAnswer` in peck-progress.json) both come from here. 200ms so the
+;; streamed text reads as live — it's a small local-file read over IPC.
+(def ^:private poll-ms 200)
 
 ;; Session-only conversation, lifted out of component-local state so a
 ;; mod+shift+p toggle (which unmounts peck-main) and the sidebar/main split
@@ -310,6 +313,14 @@
                            :background "transparent" :border "none" :padding "3px 0" :margin-top "6px"}}
           "↻ Regenerate"])]])])
 
+(rum/defc streaming-message
+  "The answer as it streams in, from peck-progress.json's :partialAnswer. Same
+  markdown renderer as a settled :assistant turn, with a trailing caret; it's
+  swapped for the real message once the turn resolves."
+  [text]
+  [:div.prose.prose-sm.max-w-none
+   (block/inline-text citation-config :markdown (str text " ▍"))])
+
 (defn- first-run-showing? [llm counts]
   (and (not (first-run/dismissed?))
        (not (first-run/ready? llm counts (first-run/steps llm counts)))))
@@ -374,7 +385,8 @@
         input (rum/react *input)
         submit! #(send-message! *loading? *progress *poll-id)
         regen! (fn [msg] (regenerate! msg *loading? *progress *poll-id))
-        activity (get @*progress :activity)]
+        activity (get @*progress :activity)
+        partial-answer (get @*progress :partialAnswer)]
     [:div.flex.flex-col {:style {:height "100%"}}
      [:div.flex-1.overflow-y-auto.px-2.pt-2
       (llm-banner/provider-banner)
@@ -385,7 +397,9 @@
                      messages))
       (when @*loading?
         [:div.py-2
-         [:div.text-sm.opacity-60 "Thinking…"]
+         (if (string/blank? partial-answer)
+           [:div.text-sm.opacity-60 "Thinking…"]
+           (streaming-message partial-answer))
          (when (seq activity)
            (telemetry/activity-feed (reverse activity)))])]
      [:div.flex.gap-2.p-2.border-t.border-gray-06


### PR DESCRIPTION
Closes #88. Pairs with kip#27 (and rides on kip#26's latency cuts).

## What

A Peck answer now appears token by token as the model writes it.

- **`poll-ms` 1000 → 200** while a turn runs — the ⚙ activity feed and the new streamed answer both come from `peck-progress.json`; it's a small local-file read over IPC.
- **`streaming-message`** renders `peck-progress.json`'s `:partialAnswer` with the same markdown renderer as a settled `:assistant` turn, plus a trailing caret. Shown in place of "Thinking…" once the first token lands; swapped for the real message when the turn resolves (`stop-poll!` already clears `*progress`).
- Providers that don't stream (the managed `kip` backend) never write `:partialAnswer`, so they keep the "Thinking…" placeholder — no regression.

No electron change: `wikiChatProgress` already returns the parsed `peck-progress.json` verbatim, so `partialAnswer` flows through.

## Test

`npx shadow-cljs compile app` — clean (0 warnings; the `git-revision-hook` warning is pre-existing). Manual: peck a "what do I know about X" question on the Anthropic or a local provider and watch the answer type in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)