### PR TITLE
dropbox: escape non-ASCII in the Dropbox-API-Arg header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to the Kip desktop app. The retrieval layer has its own
 changelog at [JWE24-code/kip](https://github.com/JWE24-code/kip/blob/main/CHANGELOG.md).
 
+## [Unreleased]
+
+- **Fixed: Dropbox sync failed on any file with an accent, em dash or other
+  non-ASCII character in its name** — "Sync this graph" aborted partway
+  through with *"Cannot convert argument to a ByteString"* and rolled itself
+  back. The file's path went into a Dropbox request header unescaped, and
+  HTTP headers can't carry those characters. They're now escaped as the
+  Dropbox API expects, so a note titled *"Weekly review — 2026"* (or in any
+  non-Latin script) syncs fine.
+
 ## [0.4.0] — 2026-08-31
 
 - **Subscribe to a calendar** — the Reminders panel gains a *Calendar feeds*

--- a/src/electron/electron/dropbox.cljs
+++ b/src/electron/electron/dropbox.cljs
@@ -282,6 +282,18 @@
       (aset "status" status)
       (aset "dropbox" (or detail body)))))
 
+(defn- api-arg
+  "JSON-encode `x` for the `Dropbox-API-Arg` HTTP header, escaping every
+   non-ASCII character as \\uXXXX. An HTTP header value must be a ByteString
+   (latin1) — `fetch` throws \"Cannot convert argument to a ByteString\" the
+   moment a file name carries an em dash, accented letter, CJK, … Dropbox
+   specifies this escaping for the header (the JSON body form doesn't need it)."
+  [x]
+  (.replace (js/JSON.stringify x)
+            (js/RegExp. "[\\u007f-\\uffff]" "g")
+            (fn [c]
+              (str "\\u" (.slice (str "000" (.toString (.charCodeAt c 0) 16)) -4)))))
+
 (defn rpc
   "POST {api-base}<endpoint> with a JSON body, JSON back. `arg` is a CLJS map."
   [endpoint arg]
@@ -312,7 +324,7 @@
           res (js/fetch (str content-base "files/download")
                         #js {:method "POST"
                              :headers #js {"Authorization" (str "Bearer " token)
-                                           "Dropbox-API-Arg" (js/JSON.stringify #js {:path remote-path})}})]
+                                           "Dropbox-API-Arg" (api-arg #js {:path remote-path})}})]
     (read-download res)))
 
 (defn get-metadata
@@ -337,7 +349,7 @@
                             #js {:method "POST"
                                  :headers #js {"Authorization" (str "Bearer " token)
                                                "Content-Type" "application/octet-stream"
-                                               "Dropbox-API-Arg" (js/JSON.stringify (bean/->js arg))}
+                                               "Dropbox-API-Arg" (api-arg (bean/->js arg))}
                                  :body buffer})
           text (.text res)]
     (if (.-ok res)


### PR DESCRIPTION
## Bug (reported on v0.4.0)

```
[DropboxSync] enable! failed for C:/Users/.../Documents/Graph (remote /Graph):
Cannot convert argument to a ByteString because the character at index 29 has a
value of 8212 which is greater than 255.
```

`8212` = U+2014, an em dash. The user has a note whose filename contains one (smart punctuation, accents, non-Latin scripts — all common). During "Sync this graph" the initial upload put that path into the **`Dropbox-API-Arg` HTTP header** via a bare `JSON.stringify`, and `fetch` rejects any header value that isn't latin1. `do-enable!`'s catch then tore the whole sync back down, so the user is left with nothing synced.

## Fix

New `api-arg` helper: `JSON.stringify` then escape every char ≥ U+007F as `\uXXXX` — exactly what [Dropbox's docs](https://www.dropbox.com/developers/documentation/http/documentation#formats) prescribe for the header. Applied to the two content-endpoint call sites (`files/upload`, `files/download`). The RPC endpoints (`files/list_folder`, `delete_v2`, …) send their arg in the JSON *body*, which needs no escaping — untouched.

Verified: `{"path":"/Graph/Weekly review — 2026 é 日.md"}` → `\u2014 \u00e9 \u65e5`, `Headers.set` no longer throws, `JSON.parse` round-trips the original path. `shadow-cljs compile electron` clean (0 warnings).

Needs a v0.4.1 patch — Dropbox sync is broken for a large fraction of real vaults as shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)