### PR TITLE
Drop in Office & PDF files, convert them for hatching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to the Kip desktop app. The retrieval layer has its own
 changelog at [JWE24-code/kip](https://github.com/JWE24-code/kip/blob/main/CHANGELOG.md).
 
+## [Unreleased]
+
+- **Drop in Word, Excel, PowerPoint and PDF files** — the Peck and Hatch
+  views now take `.docx`, `.xlsx` / `.xls` / `.csv`, `.pptx` and `.pdf`
+  alongside Markdown and text. Kip converts each to a compact Markdown
+  version on the way in — Word keeps its headings and lists, a spreadsheet
+  becomes a table per sheet, a deck becomes its slide text and notes, a PDF
+  its text — so Hatch reads a few kilobytes of prose instead of choking on
+  megabytes of binary, and the LLM bill for hatching a document drops
+  accordingly. The original file is kept aside (outside your graph, so it
+  doesn't sync or clutter `eggs/`). Old `.doc` / `.ppt` and OpenDocument
+  files ask you to re-save as the modern format.
+
 ## [0.4.1] — 2026-08-31
 
 - **Fixed: Dropbox sync failed on any file with an accent, em dash or other

--- a/src/electron/electron/handler.cljs
+++ b/src/electron/electron/handler.cljs
@@ -582,6 +582,9 @@
 (defmethod handle :wikiAddEgg [_ [_ vault-root filename content]]
   (wiki/add-egg! vault-root filename content))
 
+(defmethod handle :wikiAddOfficeSource [_ [_ vault-root filename base64]]
+  (wiki/add-office-source! vault-root filename base64))
+
 (defmethod handle :wikiPickEggs [_ [_ vault-root]]
   (wiki/pick-and-add-eggs! vault-root))
 

--- a/src/electron/electron/wiki.cljs
+++ b/src/electron/electron/wiki.cljs
@@ -24,6 +24,7 @@
   (eggs/, nest/, clucks/, .roost/) inside the open graph — see
   scripts/lib/paths.js."
   (:require ["child_process" :as child-process]
+            ["crypto" :as crypto]
             ["fs" :as fs]
             ["path" :as node-path]
             ["electron" :refer [app dialog shell]]
@@ -225,10 +226,19 @@
        (catch :default _ (resolve* nil))))))
 
 (def ^:private egg-extensions
-  "Text formats Hatch can read — a source dropped onto the app must be one of
-  these. PDF/Word would need an extraction step the retrieval layer doesn't
-  have yet."
+  "Text formats Hatch reads as-is — a source dropped onto the app is either one
+  of these or an Office/PDF file (office-extensions), converted to Markdown
+  first (add-office-source!)."
   #{".md" ".markdown" ".mdown" ".txt" ".text" ".org"})
+
+(def ^:private office-extensions
+  "Document formats scripts/office-extract.js converts to Markdown."
+  #{".docx" ".xlsx" ".xls" ".xlsm" ".csv" ".tsv" ".pptx" ".pdf"})
+
+(def ^:private legacy-office-hints
+  "Formats we don't convert → the modern one to re-save as."
+  {".doc" ".docx" ".ppt" ".pptx" ".odt" ".docx" ".odp" ".pptx"
+   ".ods" ".xlsx" ".rtf" ".docx" ".pages" ".docx" ".key" ".pptx" ".numbers" ".xlsx"})
 
 (defn- unique-egg-path
   "eggs/<filename>, or eggs/<stem> (2)<ext>, (3)<ext>… when the name is taken."
@@ -283,31 +293,120 @@
          (log-error (str "add-egg! " filename ": " (.-message e)))
          (resolve* #js {:ok false :reason (.-message e)}))))))
 
+;; --- Office / PDF drop-ins (kip-app#91) ------------------------------------
+;; A .docx/.xlsx/.pptx/.pdf can't be hatched as text. scripts/office-extract.js
+;; converts it to compact Markdown; the .md goes into eggs/ as the source, and
+;; the untouched original is kept in the app's userData (NOT the graph — so it
+;; doesn't sync or clutter eggs/).
+
+(defn- originals-dir
+  "userData/kip-source-originals/<graph-hash>/ — where a converted file's
+  original is parked. Per-graph so two graphs' \"report.docx\" don't collide."
+  [vault-root]
+  (let [h (-> (crypto/createHash "sha1") (.update (str vault-root)) (.digest "hex") (subs 0 12))]
+    (.join node-path (.getPath app "userData") "kip-source-originals" h)))
+
+(defn- unique-path
+  "`dir/filename`, or `dir/<stem> (2)<ext>`, … when the name is taken."
+  [dir filename]
+  (let [ext  (.extname node-path filename)
+        stem (subs filename 0 (- (count filename) (count ext)))]
+    (loop [n 1]
+      (let [full (.join node-path dir (if (= n 1) filename (str stem " (" n ")" ext)))]
+        (if (fs/existsSync full) (recur (inc n)) full)))))
+
+(defn- convert-kept-original!
+  "Given an original file already parked at `orig-abs`, convert it to Markdown
+  in <graph>/eggs/ via office-extract.js. Resolves a CLJS map:
+    {:ok true :name <name.md> :kind <fmt> :warnings [...]}
+    {:ok false :reason <message> :name <original>}"
+  [vault-root orig-abs]
+  (let [eggs-dir (.join node-path vault-root "eggs")
+        base     (.basename node-path orig-abs)
+        ext      (.extname node-path base)
+        md-out   (unique-path eggs-dir (str (subs base 0 (- (count base) (count ext))) ".md"))]
+    (fs/mkdirSync eggs-dir #js {:recursive true})
+    (-> (run-node-script! (script "office-extract.js") vault-root [orig-abs md-out "--json"])
+        (p/then (fn [r]
+                  (let [r (js->clj r :keywordize-keys true)]
+                    (if (:ok r)
+                      {:ok true :name (.basename node-path md-out) :kind (:kind r)
+                       :warnings (vec (or (:warnings r) []))}
+                      (do (log-error (str "office-extract " base ": " (:error r)))
+                          (try (fs/rmSync orig-abs #js {:force true}) (catch :default _ nil))
+                          {:ok false :reason (or (:error r) "conversion failed") :name base})))))
+        (p/catch (fn [e]
+                   (log-error (str "office-extract " base ": " e))
+                   (try (fs/rmSync orig-abs #js {:force true}) (catch :default _ nil))
+                   {:ok false :reason (str e) :name base})))))
+
+(defn add-office-source!
+  "Decode `base64` (a dropped .docx/.xlsx/.pptx/.pdf), park the original under
+  userData, and convert it to a Markdown Hatch source in <graph>/eggs/.
+  Resolves:
+    {:ok true :name <name.md> :kind <fmt> :warnings [...]}
+    {:ok false :reason \"no-graph\" | \"unsupported\" | <message> [:ext :hint]}"
+  [vault-root filename base64]
+  (p/create
+   (fn [resolve* _reject]
+     (try
+       (let [ext (string/lower-case (or (.extname node-path filename) ""))]
+         (cond
+           (or (string/blank? vault-root) (string/blank? filename) (not (coop-dir? vault-root)))
+           (resolve* #js {:ok false :reason "no-graph"})
+
+           (not (contains? office-extensions ext))
+           (resolve* #js {:ok false :reason "unsupported" :ext ext
+                          :hint (get legacy-office-hints ext)})
+
+           :else
+           (let [odir (originals-dir vault-root)]
+             (fs/mkdirSync odir #js {:recursive true})
+             (let [orig (unique-path odir (.basename node-path filename))]
+               (fs/writeFileSync orig (js/Buffer.from base64 "base64"))
+               (-> (convert-kept-original! vault-root orig)
+                   (p/then #(resolve* (clj->js %))))))))
+       (catch :default e
+         (log-error (str "add-office-source! " filename ": " (.-message e)))
+         (resolve* #js {:ok false :reason (.-message e)}))))))
+
 (defn pick-and-add-eggs!
-  "Open a native file picker (Markdown / text, multi-select) and copy the
-  chosen files into <graph>/eggs/. Resolves
+  "Open a native file picker (Markdown / text / Office / PDF, multi-select) and
+  add the chosen files to <graph>/eggs/ — text as-is, Office/PDF converted to
+  Markdown. Resolves
   {:canceled bool :added [names] :duplicates [names] :rejected [names]}."
   [vault-root]
   (p/let [^js res (.showOpenDialog dialog
                                    #js {:title "Add sources to your coop"
                                         :properties #js ["openFile" "multiSelections"]
-                                        :filters #js [#js {:name "Markdown / text"
-                                                           :extensions #js ["md" "markdown" "mdown" "txt" "text" "org"]}]})
-          paths (or (some-> res .-filePaths array-seq) [])]
-    (if (or (string/blank? vault-root) (empty? paths))
+                                        :filters #js [#js {:name "Documents & text"
+                                                           :extensions #js ["md" "markdown" "mdown" "txt" "text" "org"
+                                                                            "docx" "xlsx" "xls" "xlsm" "csv" "tsv" "pptx" "pdf"]}]})
+          paths (or (some-> res .-filePaths array-seq) [])
+          results (if (or (string/blank? vault-root) (empty? paths))
+                    []
+                    (let [eggs-dir (.join node-path vault-root "eggs")]
+                      (p/all
+                       (mapv (fn [path]
+                               (let [ext (string/lower-case (.extname node-path path))]
+                                 (try
+                                   (if (contains? office-extensions ext)
+                                     (let [odir (originals-dir vault-root)]
+                                       (fs/mkdirSync odir #js {:recursive true})
+                                       (let [orig (unique-path odir (.basename node-path path))]
+                                         (fs/copyFileSync path orig)
+                                         (convert-kept-original! vault-root orig)))
+                                     (write-egg-content eggs-dir (.basename node-path path)
+                                                        (fs/readFileSync path "utf8")))
+                                   (catch :default e
+                                     {:ok false :reason (.-message e) :name (.basename node-path path)}))))
+                             paths))))]
+    (if (empty? paths)
       #js {:canceled true :added #js [] :duplicates #js [] :rejected #js []}
-      (let [eggs-dir (.join node-path vault-root "eggs")
-            results  (mapv (fn [path]
-                             (try
-                               (write-egg-content eggs-dir (.basename node-path path)
-                                                  (fs/readFileSync path "utf8"))
-                               (catch :default e
-                                 {:ok false :reason (.-message e) :name (.basename node-path path)})))
-                           paths)]
-        (clj->js {:canceled   false
-                  :added      (->> results (filter #(and (:ok %) (not (:duplicate %)))) (mapv :name))
-                  :duplicates (->> results (filter :duplicate) (mapv :name))
-                  :rejected   (->> results (remove :ok) (mapv #(or (:name %) "a file")))})))))
+      (clj->js {:canceled   false
+                :added      (->> results (filter #(and (:ok %) (not (:duplicate %)))) (mapv :name))
+                :duplicates (->> results (filter :duplicate) (mapv :name))
+                :rejected   (->> results (remove :ok) (mapv #(or (:name %) "a file")))}))))
 
 (defn- count-files
   "Count of files under `dir` (recursively) matching `pred` (a fn of the

--- a/src/main/frontend/components/drop_source.cljs
+++ b/src/main/frontend/components/drop_source.cljs
@@ -1,9 +1,10 @@
 (ns frontend.components.drop-source
-  "Drag a Markdown / text file onto the Peck view or the Hatch panel and it
-  lands in <graph>/eggs/ as a Hatch source — no need to leave the app and use
-  the OS file manager. `drop-zone` wraps its children: an overlay shows while a
-  file is dragged over, a notification reports the result on drop. PDF/Word are
-  rejected with a note (the retrieval layer can't read them yet)."
+  "Drag a Markdown / text / Office / PDF file onto the Peck view or the Hatch
+  panel and it lands in <graph>/eggs/ as a Hatch source — no need to leave the
+  app and use the OS file manager. A .docx / .xlsx / .pptx / .pdf is converted
+  to Markdown on the way in (scripts/office-extract.js). `drop-zone` wraps its
+  children: an overlay shows while a file is dragged over, a notification
+  reports the result on drop."
   (:require [cljs-bean.core :as bean]
             [clojure.string :as string]
             [electron.ipc :as ipc]
@@ -16,6 +17,10 @@
             [rum.core :as rum]))
 
 (def ^:private accepted-exts #{"md" "markdown" "mdown" "txt" "text" "org"})
+(def ^:private office-exts #{"docx" "xlsx" "xls" "xlsm" "csv" "tsv" "pptx" "pdf"})
+(def ^:private legacy-hints
+  {"doc" ".docx" "ppt" ".pptx" "odt" ".docx" "odp" ".pptx" "ods" ".xlsx"
+   "rtf" ".docx" "pages" ".docx" "key" ".pptx" "numbers" ".xlsx"})
 
 (defn- vault-root [] (config/get-repo-dir (state/get-current-repo)))
 
@@ -30,27 +35,71 @@
 (defn- files-seq [^js e]
   (some-> e .-dataTransfer .-files js/Array.from seq))
 
-(defn- notify-added! [name]
-  (notification/show!
-   [:div.text-sm
-    [:div "Added " [:b name] " to " (glossary/term "eggs/") "."]
-    [:button.text-xs.underline.opacity-80.hover:opacity-100.mt-1
-     {:on-click (fn []
-                  (notification/clear-all!)
-                  (state/pub-event! [:modal/show-hatch]))}
-     "Hatch it now →"]]
-   :success false))
+(defn- notify-added!
+  ([name] (notify-added! name nil))
+  ([name detail]
+   (notification/show!
+    [:div.text-sm
+     [:div "Added " [:b name] " to " (glossary/term "eggs/") "."]
+     (when detail [:div.text-xs.opacity-70.mt-0.5 detail])
+     [:button.text-xs.underline.opacity-80.hover:opacity-100.mt-1
+      {:on-click (fn []
+                   (notification/clear-all!)
+                   (state/pub-event! [:modal/show-hatch]))}
+      "Hatch it now →"]]
+    :success false)))
+
+(defn- array-buffer->base64 [buf]
+  (let [bytes (js/Uint8Array. buf)
+        len   (.-length bytes)
+        step  8192]
+    (loop [i 0 acc ""]
+      (if (< i len)
+        (recur (+ i step)
+               (str acc (.apply js/String.fromCharCode nil
+                                (.subarray bytes i (min len (+ i step))))))
+        (js/btoa acc)))))
+
+(defn- add-office! [^js file on-added]
+  (let [name (.-name file)]
+    (-> (.arrayBuffer file)
+        (p/then (fn [buf]
+                  (ipc/ipc "wikiAddOfficeSource" (vault-root) name (array-buffer->base64 buf))))
+        (p/then (fn [r]
+                  (let [{:keys [ok name kind warnings reason]} (bean/->clj r)]
+                    (if ok
+                      (do (notify-added! name (str "converted from " (or kind "document")
+                                                   (when (seq warnings) (str " — " (first warnings)))))
+                          (coop/refresh-counts!)
+                          (when on-added (on-added name)))
+                      (notification/show!
+                       (str "Couldn't convert " (.-name file) ": " reason) :error true)))))
+        (p/catch (fn [err]
+                   (notification/show! (str "Couldn't read " name ": " err) :error true))))))
 
 (defn- add-one! [^js file on-added]
   (let [name (.-name file)
         ext  (ext-of name)]
-    (if-not (contains? accepted-exts ext)
+    (cond
+      (contains? office-exts ext)
+      (add-office! file on-added)
+
+      (contains? legacy-hints ext)
       (notification/show!
        [:div.text-sm
-        "Can't add " [:b name] " — Kip reads Markdown and text files ("
-        [:code ".md"] ", " [:code ".txt"] ", " [:code ".org"] "). "
-        "PDF and Word support is on the way."]
+        "Can't add " [:b name] " — re-save it as a " [:code (get legacy-hints ext)]
+        " and drop that instead."]
        :warning true)
+
+      (not (contains? accepted-exts ext))
+      (notification/show!
+       [:div.text-sm
+        "Can't add " [:b name] " — Kip takes Markdown / text ("
+        [:code ".md"] ", " [:code ".txt"] ", " [:code ".org"] ") and Office / PDF ("
+        [:code ".docx"] ", " [:code ".xlsx"] ", " [:code ".pptx"] ", " [:code ".pdf"] ")."]
+       :warning true)
+
+      :else
       (-> (.text file)
           (p/then #(ipc/ipc "wikiAddEgg" (vault-root) name %))
           (p/then (fn [r]

--- a/src/main/frontend/components/ingest.cljs
+++ b/src/main/frontend/components/ingest.cljs
@@ -54,7 +54,7 @@
                        (str (string/join ", " duplicates) " already in your coop.") :info true))
                     (when (seq rejected)
                       (notification/show!
-                       (str "Skipped " (count rejected) " file(s) — Kip reads Markdown and text only.")
+                       (str "Skipped " (count rejected) " file(s) — Kip takes Markdown / text and Office / PDF (.docx, .xlsx, .pptx, .pdf).")
                        :warning true))
                     (when (or (seq added) (seq duplicates))
                       (coop/refresh-counts!)


### PR DESCRIPTION
Closes #91. Needs kip#28 (the converter + CLI).

## What

Drop a `.docx` / `.xlsx` / `.xls` / `.csv` / `.pptx` / `.pdf` onto the Peck or Hatch view — or pick it via **Add source…** — and Kip converts it to compact Markdown before it becomes a Hatch source.

- **`electron/wiki.cljs`**
  - `add-office-source!` — decode the dropped bytes, park the **untouched original** in `userData/kip-source-originals/<graph-hash>/` (not the graph, so it doesn't sync or clutter `eggs/`), shell `office-extract.js --json`, drop the resulting `<name>.md` into `<graph>/eggs/` (collision-safe name).
  - `convert-kept-original!` — the shared core. `pick-and-add-eggs!` routes office files through it too; its picker filter gained the new extensions.
- **`handler.cljs`** — `:wikiAddOfficeSource`.
- **`drop_source.cljs`** — office extensions accepted (`arrayBuffer` → base64 → IPC); a `.doc` / `.ppt` / OpenDocument drop shows a "re-save it as `.docx`" hint; the generic reject copy lists the supported set.
- **`ingest.cljs`** — the picker's "skipped N files" copy updated.

Conversion is transparent: the notification says e.g. *"Added plan.md to eggs/ — converted from xlsx"*, plus any fidelity warning (a scanned PDF, a truncated giant sheet).

## Fidelity

| type | conversion |
|---|---|
| `.docx` | headings, lists, tables, bold (`mammoth`) |
| `.xlsx` / `.xls` / `.csv` | one Markdown table per sheet, blank rows/cols trimmed |
| `.pptx` | `## Slide N` + bullets + speaker notes |
| `.pdf` | text layer, with a "tables/columns/scans may be imperfect" note |

## Test

`:app` + `:electron` compile clean (0 warnings). Converter behaviour is covered by kip#28's `office.test.js` (12 cases). Manual: drop each type onto Peck, confirm the `.md` lands in `eggs/` and Hatch picks it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)