### PR TITLE
changelog: Peck web-search fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to the Kip desktop app. The retrieval layer has its own
 changelog at [JWE24-code/kip](https://github.com/JWE24-code/kip/blob/main/CHANGELOG.md).
 
+## [Unreleased]
+
+- **Peck searches the web when your notes come up short** — ask a question
+  your nest doesn't cover and Kip no longer just shrugs: it runs a web search
+  and answers from that, offering the results as a source you can hatch. Uses
+  the built-in web search (DuckDuckGo, no key needed); it stays out of the way
+  on a regenerate and when a skill already searched. Turn off web search in
+  Settings → Skills to keep it strictly notes-only.
+
 ## [0.4.2] — 2026-08-31
 
 - **The answer streams in** — a Peck answer now appears word by word as the


### PR DESCRIPTION
Closes #93. Retrieval-layer feature (kip#29) — this PR is just the CHANGELOG entry; there is no app code change.

When Peck can't answer from the nest, it now runs the built-in `web-search` skill (DuckDuckGo, keyless) and answers from the results, offering them as a hatchable source. Stays out of the way on a regenerate and when a skill already searched; falls through to the old "nothing in your nest" state when web search is disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)