### PR TITLE
updater: repoint launcher symlinks after an AppImage update (kip-app#98)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to the Kip desktop app. The retrieval layer has its own
 changelog at [JWE24-code/kip](https://github.com/JWE24-code/kip/blob/main/CHANGELOG.md).
 
+## [Unreleased]
+
+- **App updates no longer break the desktop launcher** — if you launch Kip
+  through a stable symlink (`~/Applications/Kip.AppImage` pointing at the
+  versioned file, the way `Kip.desktop` does), every self-update used to leave
+  that symlink aimed at the deleted old version, so the launcher silently did
+  nothing until you relaunched by hand. The updater now repoints any symlink
+  that referenced the old file the moment it installs the new one (kip-app#98).
+
 ## [0.4.3] — 2026-08-31
 
 - **Peck searches the web when your notes come up short** — ask a question

--- a/src/electron/electron/updater.cljs
+++ b/src/electron/electron/updater.cljs
@@ -14,8 +14,15 @@
 
   Self-updates a NSIS install (Windows) or an AppImage (Linux) only — a
   portable tar.gz / folder unzip or a dev run has no updater, and
-  download-update! rejects with a 'grab it yourself' message."
-  (:require ["electron-updater" :refer [autoUpdater]]
+  download-update! rejects with a 'grab it yourself' message.
+
+  On Linux the AppImage install lands under a new versioned name
+  (AppImageUpdater.doInstall unlinks the old file first), so wire! also listens
+  for 'appimage-filename-updated' and repoints launcher symlinks that
+  referenced the old name (#98)."
+  (:require ["fs" :as fs]
+            ["path" :as node-path]
+            ["electron-updater" :refer [autoUpdater]]
             [clojure.string :as string]
             [electron.logger :as logger]
             [electron.utils :as utils]
@@ -36,6 +43,55 @@
   []
   (boolean (try (.isUpdaterActive autoUpdater)
                 (catch :default _ false))))
+
+(defn- replace-symlink!
+  "Point the symlink `link` at `target`, via a same-directory temp link renamed
+  over it — a crash mid-repoint then leaves the old link intact rather than no
+  launcher at all. Same style (absolute vs relative) as callers pass."
+  [link target]
+  (let [tmp (node-path/join (node-path/dirname link)
+                            (str "." (node-path/basename link) ".kip-relink"))]
+    (try (fs/unlinkSync tmp) (catch :default _))
+    (fs/symlinkSync target tmp)
+    (fs/renameSync tmp link)))
+
+(defn- repoint-launcher-symlinks!
+  "#98: the AppImage install unlinks the old versioned file and moves the new
+  build next to it under a fresh versioned name, so launcher symlinks set up
+  against the old name (~/Applications/Kip.AppImage -> Kip-<v>-x86_64.AppImage,
+  which Kip.desktop execs) are left dangling on every update. Retarget every
+  symlink in the same directory that resolved to `old-file`, keeping each
+  link's absolute/relative style."
+  [old-file new-file]
+  (let [dir (node-path/dirname old-file)
+        names (try (seq (fs/readdirSync dir)) (catch :default _))]
+    (doseq [name names
+            :let [link (node-path/join dir name)]
+            :when (not= link new-file)
+            :let [target (try (fs/readlinkSync link) (catch :default _))]
+            :when (and target (= (node-path/resolve dir target) old-file))]
+      (let [new-target (if (node-path/isAbsolute target)
+                         new-file
+                         (node-path/relative dir new-file))]
+        (try
+          (replace-symlink! link new-target)
+          (debug "repointed launcher symlink" link "->" new-target)
+          (catch :default e
+            (logger/warn "[updater]" "couldn't repoint launcher symlink" link
+                         "-" (or (.-message e) e))))))))
+
+(defn- fix-launcher-symlinks!
+  "Handler for 'appimage-filename-updated', which doInstall emits right after
+  the rename. The old path is still in APPIMAGE at that point — doInstall
+  doesn't touch the env var. AppImage-only; no-op elsewhere."
+  [new-file]
+  (when-let [old-file (.-APPIMAGE js/process.env)]
+    (when new-file
+      (try
+        (repoint-launcher-symlinks! old-file new-file)
+        (catch :default e
+          (logger/warn "[updater]" "launcher symlink repoint failed:"
+                       (or (.-message e) e)))))))
 
 (defn wire!
   "Idempotent. Configure electron-updater and forward its events to `win`:
@@ -65,7 +121,8 @@
              (utils/send-to-renderer win "auto-updater-downloaded"
                                      #js {:name    (.-version info)
                                           :version (.-version info)
-                                          :notes   (.-releaseNotes info)}))))))
+                                          :notes   (.-releaseNotes info)})))
+      (.on "appimage-filename-updated" fix-launcher-symlinks!))))
 
 (defn download-update!
   "Check the feed, then download. Progress + completion arrive as the events


### PR DESCRIPTION
## Problem

Every AppImage self-update leaves a stable launcher symlink dangling — reproduced on all three updates so far (0.3.7→0.4.0, 0.4.0→0.4.1, 0.4.1→0.4.3). Setup: `~/Applications/Kip.AppImage` → the versioned file, referenced by `Kip.desktop`. After each update the desktop entry silently does nothing.

Root cause (verified against the shipped electron-updater 6.3.9): `AppImageUpdater.doInstall` unlinks `process.env.APPIMAGE` — which the AppImage runtime sets to the **realpath**, so a symlinked launch yields the versioned name — and moves the new build in under a fresh versioned name. Upstream's "preserve custom name" branch (electron-builder#2964) is unreachable when launching through a symlink.

## Fix

`wire!` now listens for `appimage-filename-updated` — the event `doInstall` emits synchronously right after the rename — and repoints launcher symlinks:

- reads the old path from `process.env.APPIMAGE` (the shipped `doInstall` never reassigns it, so it still holds the pre-rename path at event time)
- scans `dirname(APPIMAGE)` for symlinks resolving to the old file; `readlinkSync` throwing on regular files/dirs makes the filter exact
- retargets each link to the new file, **preserving its absolute/relative style**, via a same-dir temp symlink + `rename` — a crash mid-repoint leaves the old (working) link, never no launcher
- per-link failures log and continue; the handler itself is guarded so the quit/install path is never disturbed

AppImage-only: the event only ever fires from the AppImage updater, so NSIS/Windows and dev runs are untouched.

## Verification

- `clojure -M:cljs compile electron` — clean, 0 warnings
- Node simulation of the exact fs call sequence against the #98 scenario: relative link (`Kip.AppImage → Kip-0.4.3-x86_64.AppImage`), absolute link, `./`-segment link, and a second link to the same target all repointed; unrelated symlink, regular files and dirs untouched; no temp links left behind; idempotent
- End-to-end proof lands with the first real self-update against a release built from this commit

Not addressed here (deliberately): dropping the version from the artifact name (`artifactName: Kip.${ext}`) so the updater overwrites in place — that's a release-asset naming change, better decided alongside release automation.

Fixes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)