### PR TITLE
Peck lint warnings (#116) + fix the #112 file-back paren imbalance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ changelog at [JWE24-code/kip](https://github.com/JWE24-code/kip/blob/main/CHANGE
 
 ## [Unreleased]
 
+- **Keep a Peck answer in your nest** — a settled answer that came from your
+  notes now has a "⬇ File into the nest" control: it becomes a `concept` page
+  tagged `from-peck`, so Peck can find it next time you ask. Hidden for
+  web-backed answers and answers with no source pages. Every question you ask
+  in the panel is also recorded once in the Coop activity view, the way the
+  CLI already did (kip-app#112).
+- **Peck flags its own shaky sources** — if an answer leans on a page your
+  last groom flagged (orphaned, contradicted, a near-duplicate, drifted from
+  disk), a short "⚠" note now appears under the answer naming the problem.
+  Nothing shows for a clean answer or a nest you've never groomed
+  (kip-app#116).
+- **Peck won't quietly pick a side** — when the pages behind an answer
+  disagree on a date or a value, Peck now says so and cites both instead of
+  presenting one as settled fact. Groom's known contradictions for the pages
+  in play are fed into the answer too (kip-app#116).
+- **Hatch updates read what's already on the page** — when a source touches a
+  page you already have, the update is now written as a delta against the
+  existing content instead of a fresh restatement drafted blind, so pages stop
+  accumulating near-duplicate paragraphs that a later groom has to flag
+  (kip-app#114).
+
 ## [0.4.4] — 2026-09-02
 
 - **Whiteboards now run on Excalidraw** — the tldraw-based whiteboard has been

--- a/src/main/frontend/components/chat.cljs
+++ b/src/main/frontend/components/chat.cljs
@@ -289,7 +289,7 @@
          [:span
           (if (= (:action s) "update") "appended to " "filed as ")
           (block/inline-text citation-config :markdown (str "[[" (:slug s) "]]"))
-          (when (:path s) [:span {:style {:opacity 0.6}} (str "  ·  " (:path s))])]])
+          (when (:path s) [:span {:style {:opacity 0.6}} (str "  ·  " (:path s))])])]
 
       (= s :saving)
       [:span {:style {:font-size "9px" :opacity 0.5 :margin-top "6px"}} "filing…"]

--- a/src/main/frontend/components/chat.cljs
+++ b/src/main/frontend/components/chat.cljs
@@ -65,7 +65,7 @@
    :pages pages})
 
 (defn- turn->message [result]
-  (let [{:keys [intent answer learned note pages steps callId arenaId webSource citedSlugs candidateSlugs]} result]
+  (let [{:keys [intent answer learned note pages steps callId arenaId webSource citedSlugs candidateSlugs lintWarnings]} result]
     (cond
       (= intent "statement")
       (if learned
@@ -78,7 +78,9 @@
        ;; kept on the message so "file into the nest" has its inputs
        ;; (kip-app#112) — cited vs candidate is also the retrieval-breadth
        ;; signal the evidence view (#117) will want.
-       :cited-slugs citedSlugs :candidate-slugs candidateSlugs}
+       :cited-slugs citedSlugs :candidate-slugs candidateSlugs
+       ;; groom's findings for the pages this answer cited (kip-app#116)
+       :lint-warnings lintWarnings}
 
       (= intent "reminder")
       {:role :assistant :text "Reminder noted — check the Reminders panel." :steps steps}
@@ -303,8 +305,21 @@
                         :border "none" :padding "3px 0" :margin-top "6px"}}
        "⬇ File into the nest"])))
 
+(rum/defc lint-warnings-cp
+  "groom's findings for the pages a Peck answer cited (kip-app#116) — shown
+  under the answer so a claim drawn from a flagged page (orphaned, contradicted,
+  a near-duplicate, …) carries that caveat."
+  [warnings]
+  [:div {:style {:font-size "11px" :opacity 0.75 :margin-top "6px"
+                 :border-left "2px solid var(--ls-warning-color, #d97706)" :padding-left "8px"}}
+   (for [{:keys [slug kind note]} warnings]
+     [:div {:key (str slug "/" kind) :style {:margin "2px 0"}}
+      "⚠ "
+      (block/inline-text citation-config :markdown (str "[[" slug "]]"))
+      " — " note])])
+
 (rum/defc message-cp
-  [{:keys [role text pages steps call-id arena-id web-source answer? regen? candidate-slugs] :as msg}
+  [{:keys [role text pages steps call-id arena-id web-source answer? regen? candidate-slugs lint-warnings] :as msg}
    {:keys [on-regenerate busy?]}]
   [:div.py-2
    (case role
@@ -336,6 +351,7 @@
          "↻ regenerated"])
       (when (seq steps) (steps-line steps))
       [:div.prose.prose-sm.max-w-none (block/inline-text citation-config :markdown text)]
+      (when (seq lint-warnings) (lint-warnings-cp lint-warnings))
       (when (and (:filename web-source) (:content web-source))
         (web-source-widget web-source))
       (when (and arena-id (pref-signals/enabled?))


### PR DESCRIPTION
kip-app half of roadmap issue **#116**, plus a build-breaker fix for **#112**.
Retrieval-layer half: JWE24-code/kip#39.

## ⚠️ First commit fixes a broken `version/file`

`1a893f401` ("chat: file-back confirmation shows the written page path")
added the `· <path>` span to `file-answer-widget` but left the brackets
unbalanced — an `]` where a `)` was needed, closing the outer `[:span]`
before the `(if :error)` around it. `chat.cljs` no longer reads, so the
namespace fails to compile. `8d8213482` rebalances it (one bracket). The
current default branch does not build without this.

## #116 — groom lint warnings under a Peck answer

`peckTurn` now returns `lintWarnings` (from JWE24-code/kip#39) — groom's
findings for the pages an answer cited. Rendered as a short `⚠` caveat strip
under the answer prose, `[[slug]]` linked. Nothing shows for a clean answer
or a nest that has never been groomed.

Also folds in the answer-prompt side of #116 (contradiction handling) via
the retrieval-layer PR — no app change needed for that part.

## Verification

- `chat.cljs` parses (34 → 35 forms) and `clojure -M:clj-kondo` is clean.
- `yarn cljs:test` compiles the full app + test build with no new warnings.
- CHANGELOG updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)