### PR TITLE
Rename the source folder: eggs/ → pages/

### DIFF
--- a/src/electron/electron/handler.cljs
+++ b/src/electron/electron/handler.cljs
@@ -579,14 +579,14 @@
 (defmethod handle :wikiIngestMetrics [_ [_ vault-root]]
   (wiki/hatch-metrics! vault-root))
 
-(defmethod handle :wikiAddEgg [_ [_ vault-root filename content]]
-  (wiki/add-egg! vault-root filename content))
+(defmethod handle :wikiAddSource [_ [_ vault-root filename content]]
+  (wiki/add-source! vault-root filename content))
 
 (defmethod handle :wikiAddOfficeSource [_ [_ vault-root filename base64]]
   (wiki/add-office-source! vault-root filename base64))
 
-(defmethod handle :wikiPickEggs [_ [_ vault-root]]
-  (wiki/pick-and-add-eggs! vault-root))
+(defmethod handle :wikiPickSources [_ [_ vault-root]]
+  (wiki/pick-and-add-sources! vault-root))
 
 (defmethod handle :wikiCoopCounts [_ [_ vault-root]]
   (wiki/coop-counts! vault-root))

--- a/src/electron/electron/wiki.cljs
+++ b/src/electron/electron/wiki.cljs
@@ -21,7 +21,7 @@
 
   Every call takes the current graph's directory as `vault-root` and exports
   it as KIP_COOP_ROOT for the child, so the scripts operate on the coop
-  (eggs/, nest/, clucks/, .roost/) inside the open graph — see
+  (pages/, nest/, clucks/, .roost/) inside the open graph — see
   scripts/lib/paths.js."
   (:require ["child_process" :as child-process]
             ["crypto" :as crypto]
@@ -159,7 +159,7 @@
        (catch :default _ (resolve* nil))))))
 
 (defn hatch-preview!
-  "What a 'Hatch sources' run would touch — new/changed files in eggs/,
+  "What a 'Hatch sources' run would touch — new/changed files in pages/,
   journals/, pages/, plus the oversized and empty ones it skips. No LLM
   calls. Resolves to {:pending [{:source :kind :kb :status}] :oversized [...]
   :empty [...] :changedCount n :totalKb n} — status distinguishes a brand-new
@@ -227,7 +227,7 @@
        (resolve* (js/JSON.parse (fs/readFileSync (roost-file vault-root "hatch-metrics.json") "utf8")))
        (catch :default _ (resolve* nil))))))
 
-(def ^:private egg-extensions
+(def ^:private source-extensions
   "Text formats Hatch reads as-is — a source dropped onto the app is either one
   of these or an Office/PDF file (office-extensions), converted to Markdown
   first (add-office-source!)."
@@ -242,43 +242,43 @@
   {".doc" ".docx" ".ppt" ".pptx" ".odt" ".docx" ".odp" ".pptx"
    ".ods" ".xlsx" ".rtf" ".docx" ".pages" ".docx" ".key" ".pptx" ".numbers" ".xlsx"})
 
-(defn- unique-egg-path
-  "eggs/<filename>, or eggs/<stem> (2)<ext>, (3)<ext>… when the name is taken."
-  [eggs-dir filename]
+(defn- unique-source-path
+  "pages/<filename>, or pages/<stem> (2)<ext>, (3)<ext>… when the name is taken."
+  [sources-dir filename]
   (let [ext  (.extname node-path filename)
         stem (subs filename 0 (- (count filename) (count ext)))]
     (loop [n 1]
       (let [nm   (if (= n 1) filename (str stem " (" n ")" ext))
-            full (.join node-path eggs-dir nm)]
+            full (.join node-path sources-dir nm)]
         (if (fs/existsSync full) (recur (inc n)) [nm full])))))
 
-(defn- write-egg-content
+(defn- write-source-content
   "Sync core: validate the extension, skip a byte-identical file already in
-  `eggs-dir`, otherwise write `content` under a non-colliding name. Returns a
+  `sources-dir`, otherwise write `content` under a non-colliding name. Returns a
   CLJS map: {:ok true :name ...} / {:ok true :name ... :duplicate ...} /
   {:ok false :reason ...}."
-  [eggs-dir basename content]
+  [sources-dir basename content]
   (let [ext (string/lower-case (or (.extname node-path basename) ""))]
-    (if-not (contains? egg-extensions ext)
+    (if-not (contains? source-extensions ext)
       {:ok false :reason "unsupported" :ext ext}
       (do
-        (fs/mkdirSync eggs-dir #js {:recursive true})
-        (if-let [dup (->> (fs/readdirSync eggs-dir)
+        (fs/mkdirSync sources-dir #js {:recursive true})
+        (if-let [dup (->> (fs/readdirSync sources-dir)
                           (filter (fn [nm]
-                                    (let [p (.join node-path eggs-dir nm)]
+                                    (let [p (.join node-path sources-dir nm)]
                                       (and (try (.isFile (fs/statSync p)) (catch :default _ false))
                                            (= content (fs/readFileSync p "utf8"))))))
                           first)]
           {:ok true :name dup :duplicate dup}
-          (let [[nm full] (unique-egg-path eggs-dir basename)]
+          (let [[nm full] (unique-source-path sources-dir basename)]
             (fs/writeFileSync full content "utf8")
             {:ok true :name nm}))))))
 
-(defn add-egg!
-  "Write `content` (a dropped file's text) into <graph>/eggs/ under `filename`,
+(defn add-source!
+  "Write `content` (a dropped file's text) into <graph>/pages/ under `filename`,
   so it becomes a Hatch source. Resolves:
     {:ok true  :name <name>}                     — written
-    {:ok true  :name <name> :duplicate <name>}   — identical text already in eggs/
+    {:ok true  :name <name> :duplicate <name>}   — identical text already in pages/
     {:ok false :reason \"no-graph\"}
     {:ok false :reason \"unsupported\" :ext <ext>}
     {:ok false :reason <message>}"
@@ -288,18 +288,18 @@
      (try
        (if (or (string/blank? vault-root) (string/blank? filename) (not (coop-dir? vault-root)))
          (resolve* #js {:ok false :reason "no-graph"})
-         (resolve* (clj->js (write-egg-content (.join node-path vault-root "eggs")
+         (resolve* (clj->js (write-source-content (.join node-path vault-root "pages")
                                                (.basename node-path filename)
                                                content))))
        (catch :default e
-         (log-error (str "add-egg! " filename ": " (.-message e)))
+         (log-error (str "add-source! " filename ": " (.-message e)))
          (resolve* #js {:ok false :reason (.-message e)}))))))
 
 ;; --- Office / PDF drop-ins (kip-app#91) ------------------------------------
 ;; A .docx/.xlsx/.pptx/.pdf can't be hatched as text. scripts/office-extract.js
-;; converts it to compact Markdown; the .md goes into eggs/ as the source, and
+;; converts it to compact Markdown; the .md goes into pages/ as the source, and
 ;; the untouched original is kept in the app's userData (NOT the graph — so it
-;; doesn't sync or clutter eggs/).
+;; doesn't sync or clutter pages/).
 
 (defn- originals-dir
   "userData/kip-source-originals/<graph-hash>/ — where a converted file's
@@ -319,15 +319,15 @@
 
 (defn- convert-kept-original!
   "Given an original file already parked at `orig-abs`, convert it to Markdown
-  in <graph>/eggs/ via office-extract.js. Resolves a CLJS map:
+  in <graph>/pages/ via office-extract.js. Resolves a CLJS map:
     {:ok true :name <name.md> :kind <fmt> :warnings [...]}
     {:ok false :reason <message> :name <original>}"
   [vault-root orig-abs]
-  (let [eggs-dir (.join node-path vault-root "eggs")
+  (let [sources-dir (.join node-path vault-root "pages")
         base     (.basename node-path orig-abs)
         ext      (.extname node-path base)
-        md-out   (unique-path eggs-dir (str (subs base 0 (- (count base) (count ext))) ".md"))]
-    (fs/mkdirSync eggs-dir #js {:recursive true})
+        md-out   (unique-path sources-dir (str (subs base 0 (- (count base) (count ext))) ".md"))]
+    (fs/mkdirSync sources-dir #js {:recursive true})
     (-> (run-node-script! (script "office-extract.js") vault-root [orig-abs md-out "--json"])
         (p/then (fn [r]
                   (let [r (js->clj r :keywordize-keys true)]
@@ -344,7 +344,7 @@
 
 (defn add-office-source!
   "Decode `base64` (a dropped .docx/.xlsx/.pptx/.pdf), park the original under
-  userData, and convert it to a Markdown Hatch source in <graph>/eggs/.
+  userData, and convert it to a Markdown Hatch source in <graph>/pages/.
   Resolves:
     {:ok true :name <name.md> :kind <fmt> :warnings [...]}
     {:ok false :reason \"no-graph\" | \"unsupported\" | <message> [:ext :hint]}"
@@ -372,9 +372,9 @@
          (log-error (str "add-office-source! " filename ": " (.-message e)))
          (resolve* #js {:ok false :reason (.-message e)}))))))
 
-(defn pick-and-add-eggs!
+(defn pick-and-add-sources!
   "Open a native file picker (Markdown / text / Office / PDF, multi-select) and
-  add the chosen files to <graph>/eggs/ — text as-is, Office/PDF converted to
+  add the chosen files to <graph>/pages/ — text as-is, Office/PDF converted to
   Markdown. Resolves
   {:canceled bool :added [names] :duplicates [names] :rejected [names]}."
   [vault-root]
@@ -387,7 +387,7 @@
           paths (or (some-> res .-filePaths array-seq) [])
           results (if (or (string/blank? vault-root) (empty? paths))
                     []
-                    (let [eggs-dir (.join node-path vault-root "eggs")]
+                    (let [sources-dir (.join node-path vault-root "pages")]
                       (p/all
                        (mapv (fn [path]
                                (let [ext (string/lower-case (.extname node-path path))]
@@ -398,7 +398,7 @@
                                        (let [orig (unique-path odir (.basename node-path path))]
                                          (fs/copyFileSync path orig)
                                          (convert-kept-original! vault-root orig)))
-                                     (write-egg-content eggs-dir (.basename node-path path)
+                                     (write-source-content sources-dir (.basename node-path path)
                                                         (fs/readFileSync path "utf8")))
                                    (catch :default e
                                      {:ok false :reason (.-message e) :name (.basename node-path path)}))))
@@ -422,16 +422,16 @@
 
 (defn coop-counts!
   "Cheap fs read for the first-run checklist: how many source files sit in
-  eggs/ and how many pages exist under nest/ (index.md, which is generated,
+  pages/ and how many pages exist under nest/ (index.md, which is generated,
   doesn't count). Both 0 before the folders are created. No subprocess."
   [vault-root]
   (p/create
    (fn [resolve* _reject]
      (if (string/blank? vault-root)
-       (resolve* #js {:eggs 0 :nestPages 0})
-       (resolve* #js {:eggs      (count-files (.join node-path vault-root "eggs")
-                                              #(contains? egg-extensions (string/lower-case (.extname node-path %))))
-                      :nestPages (count-files (.join node-path vault-root "nest")
+        (resolve* #js {:sourceFiles 0 :nestPages 0})
+        (resolve* #js {:sourceFiles      (count-files (.join node-path vault-root "pages")
+                                               #(contains? source-extensions (string/lower-case (.extname node-path %))))
+                       :nestPages (count-files (.join node-path vault-root "nest")
                                               #(and (= ".md" (string/lower-case (.extname node-path %)))
                                                     (not= "index.md" (.basename node-path %))))})))))
 
@@ -447,7 +447,7 @@
 
 (defn coop-summary!
   "A read-only snapshot of the open coop for the 'Your coop' panel: sources in
-  eggs/, nest pages by type, and the last hatch / last groom times (ms epoch,
+  pages/, nest pages by type, and the last hatch / last groom times (ms epoch,
   nil if never). Plain fs reads — no subprocess."
   [vault-root]
   (p/create
@@ -455,8 +455,8 @@
      (if (string/blank? vault-root)
        (resolve* #js {})
        (let [nest (.join node-path vault-root "nest")]
-         (resolve* #js {:eggs        (count-files (.join node-path vault-root "eggs")
-                                                  #(contains? egg-extensions (string/lower-case (.extname node-path %))))
+          (resolve* #js {:sourceFiles        (count-files (.join node-path vault-root "pages")
+                                                   #(contains? source-extensions (string/lower-case (.extname node-path %))))
                         :entities    (count-files (.join node-path nest "entities") md-file?)
                         :concepts    (count-files (.join node-path nest "concepts") md-file?)
                         :sources     (count-files (.join node-path nest "sources") md-file?)

--- a/src/main/frontend/components/chat.cljs
+++ b/src/main/frontend/components/chat.cljs
@@ -239,13 +239,13 @@
      (when (some? @*picked) [:span {:style {:opacity 0.45}} "logged"])]))
 
 ;; --- web-search → source (kip-app#81) — when a turn ran web-search, offer to
-;; keep its results as an eggs/ source doc so they can be hatched into the nest.
+;; keep its results as a pages/ source doc so they can be hatched into the nest.
 (rum/defcs web-source-widget < (rum/local nil ::st)
   [state {:keys [filename content]}]
   (let [*st (::st state)
         save! (fn []
                 (reset! *st :saving)
-                (-> (ipc/ipc "wikiAddEgg" (vault-root) filename content)
+                (-> (ipc/ipc "wikiAddSource" (vault-root) filename content)
                     (p/then (fn [r] (reset! *st (bean/->clj r))))
                     (p/catch (fn [e] (reset! *st {:ok false :reason (str e)})))))
         s @*st]
@@ -256,7 +256,7 @@
          [:span {:style {:opacity 0.6}}
           (if (:duplicate s)
             (str "Already in your sources as " (:name s) ".")
-            (str "Saved to eggs/" (:name s) " — run Hatch to add it to your nest."))]
+            (str "Saved to pages/" (:name s) " — run Hatch to add it to your nest."))]
          [:span {:style {:color "#c0392b"}} (str "Couldn't save: " (or (:reason s) "unknown error"))])
 
        (= s :saving) [:span {:style {:opacity 0.5}} "Saving…"]

--- a/src/main/frontend/components/container.cljs
+++ b/src/main/frontend/components/container.cljs
@@ -800,7 +800,7 @@
          [:div.text-sm.opacity-50.text-center {:style {:padding "3rem 1rem"}}
           "No journals yet. Press "
           [:code (if util/mac? "⌘1" "Ctrl+1")]
-          " for Peck, or drop a file in the graph's eggs/ folder and run Hatch."])])))
+           " for Peck, or drop a file in the graph's pages/ folder and run Hatch."])])))
 
 (defn- hide-context-menu-and-clear-selection
   [e]

--- a/src/main/frontend/components/coop_glossary.cljs
+++ b/src/main/frontend/components/coop_glossary.cljs
@@ -6,7 +6,7 @@
 
 (def glosses
   "Folder name (no slash, no dot) → what it actually is."
-  {"eggs"     "your source documents — drop files here"
+  {"pages"    "your notes and source documents — everything Kip reads and hatches"
    "nest"     "the cross-linked wiki Kip builds from them"
    "clucks"   "Kip's activity log"
    "roost"    "the search index — disposable, rebuilt any time"
@@ -17,16 +17,16 @@
 
 (defn term
   "A `<code>` tag for a metaphor folder name with its gloss as a tooltip.
-  `(term \"eggs/\")` or `(term \"eggs\" \"the eggs folder\")`."
+  `(term \"pages/\")` or `(term \"pages\" \"the pages folder\")`."
   ([label] (term label label))
   ([k label]
    (let [g (get glosses (key-for k))]
      [:code (cond-> {} g (assoc :title g)) label])))
 
 (defn legend
-  "eggs = … · nest = … · clucks = … — for the help panel and coop-map."
+  "pages = … · nest = … · clucks = … — for the help panel and coop-map."
   []
   [:div.text-xs.opacity-60.leading-relaxed
-   (->> ["eggs" "nest" "clucks" "roost" "henhouse"]
+   (->> ["pages" "nest" "clucks" "roost" "henhouse"]
         (map (fn [k] (str k " = " (get glosses k))))
         (string/join "  ·  "))])

--- a/src/main/frontend/components/drop_source.cljs
+++ b/src/main/frontend/components/drop_source.cljs
@@ -1,6 +1,6 @@
 (ns frontend.components.drop-source
   "Drag a Markdown / text / Office / PDF file onto the Peck view or the Hatch
-  panel and it lands in <graph>/eggs/ as a Hatch source — no need to leave the
+  panel and it lands in <graph>/pages/ as a Hatch source — no need to leave the
   app and use the OS file manager. A .docx / .xlsx / .pptx / .pdf is converted
   to Markdown on the way in (scripts/office-extract.js). `drop-zone` wraps its
   children: an overlay shows while a file is dragged over, a notification
@@ -40,7 +40,7 @@
   ([name detail]
    (notification/show!
     [:div.text-sm
-     [:div "Added " [:b name] " to " (glossary/term "eggs/") "."]
+     [:div "Added " [:b name] " to " (glossary/term "pages/") "."]
      (when detail [:div.text-xs.opacity-70.mt-0.5 detail])
      [:button.text-xs.underline.opacity-80.hover:opacity-100.mt-1
       {:on-click (fn []
@@ -101,7 +101,7 @@
 
       :else
       (-> (.text file)
-          (p/then #(ipc/ipc "wikiAddEgg" (vault-root) name %))
+           (p/then #(ipc/ipc "wikiAddSource" (vault-root) name %))
           (p/then (fn [r]
                     (let [{:keys [ok name duplicate reason]} (bean/->clj r)]
                       (cond

--- a/src/main/frontend/components/first_run.cljs
+++ b/src/main/frontend/components/first_run.cljs
@@ -28,8 +28,8 @@
   [{:label "Set an LLM provider"
     :done? (boolean (:configured? llm))
     :on-click #(state/open-settings! :llm)}
-   {:label "Add a source"
-    :done? (pos? (:eggs counts 0))
+    {:label "Add a source"
+     :done? (pos? (:sourceFiles counts 0))
     :note "drop a Markdown or text file anywhere on this panel"}
    {:label "Hatch it into The Nest"
     :done? (pos? (:nestPages counts 0))

--- a/src/main/frontend/components/ingest.cljs
+++ b/src/main/frontend/components/ingest.cljs
@@ -1,6 +1,6 @@
 (ns frontend.components.ingest
-  "The Hatch workflow's UI: turns new-or-changed files in eggs/, journals/
-  and pages/ into nest pages, in batches, with no per-file review. Backed by
+  "The Hatch workflow's UI: turns new-or-changed files in pages/ and
+  journals/ into nest pages, in batches, with no per-file review. Backed by
   scripts/hatch-all.js via the :wikiIngestPreview / :wikiIngestBatch /
   :wikiIngestProgress IPC channels (electron.wiki shells out — same
   one-code-path approach as the Coop status and Peck panels).
@@ -41,14 +41,14 @@
       (p/catch (fn [e] (reset! *error (str e))))
       (p/finally (fn [] (reset! *busy? false)))))
 
-(defn- pick-eggs! [*preview *error *busy?]
-  (-> (ipc/ipc "wikiPickEggs" (vault-root))
+(defn- pick-sources! [*preview *error *busy?]
+  (-> (ipc/ipc "wikiPickSources" (vault-root))
       (p/then (fn [r]
                 (let [{:keys [canceled added duplicates rejected]} (bean/->clj r)]
                   (when-not canceled
                     (when (seq added)
                       (notification/show!
-                       (str "Added " (string/join ", " added) " to eggs/.") :success true))
+                       (str "Added " (string/join ", " added) " to pages/.") :success true))
                     (when (seq duplicates)
                       (notification/show!
                        (str (string/join ", " duplicates) " already in your coop.") :info true))
@@ -305,21 +305,21 @@
      {:on-added (fn [_] (when-not demo? (load-preview! *preview *error *busy?)))}
      [:div.w-full.mx-auto {:class "md:max-w-[600px]"}
       [:h2#modal-headline.text-xl.mb-3 "Hatch sources"]
-     [:p.text-sm.opacity-70.mb-3
-      "Turns new or changed files in " (glossary/term "eggs/") ", " [:code "journals/"] " and "
-      [:code "pages/"] " into nest pages — no per-file review. Runs in batches of "
-      (str batch-size) "."]
+      [:p.text-sm.opacity-70.mb-3
+       "Turns new or changed files in " (glossary/term "pages/") " and "
+       [:code "journals/"] " into nest pages — no per-file review. Runs in batches of "
+       (str batch-size) "."]
 
      (if demo?
        [:div.text-sm.opacity-70.my-2
-        "Open a folder as your graph first — " (glossary/term "eggs/")
+        "Open a folder as your graph first — " (glossary/term "pages/")
         " and the rest of the coop live inside it. Use the graph menu at the top left."]
        [:<>
 
      (when-not @*busy?
        [:div.mb-3
         (ui/button {:variant :outline :size :sm
-                    :on-click #(pick-eggs! *preview *error *busy?)}
+                    :on-click #(pick-sources! *preview *error *busy?)}
                    "Add source…")
         (ui/button {:variant :outline :size :sm :class "ml-2"
                     :on-click #(swap! *paste? not)}

--- a/src/main/frontend/components/onboarding.cljs
+++ b/src/main/frontend/components/onboarding.cljs
@@ -27,7 +27,7 @@
 
    [:p.mt-4.mb-1 [:b "How it fits together"]]
    [:ul.text-sm.opacity-80
-    [:li [:b "Hatch"] " — a file you drop in " (glossary/term "eggs/") " becomes linked "
+    [:li [:b "Hatch"] " — a file you drop in " (glossary/term "pages/") " becomes linked "
      [:code "entity"] " / " [:code "concept"] " / " [:code "source"] " pages under The Nest."]
     [:li [:b "Peck"] " — ask the nest a question (answers cite " [:code "[[pages]]"]
      "), or tell it a fact or an upcoming meeting."]
@@ -35,7 +35,7 @@
 
    [:p.mt-4.mb-1 [:b "The coop"]]
    [:ul.text-sm.opacity-80
-    [:li (glossary/term "eggs/") " — the source documents you add"]
+    [:li (glossary/term "pages/") " — your notes and the source documents you add"]
     [:li (glossary/term "nest/") " — the LLM-maintained wiki"]
     [:li (glossary/term "clucks/") " — the activity log"]
     [:li (glossary/term "henhouse" ".henhouse/") " — LLM provider + skills config"]

--- a/src/main/frontend/components/paste_source.cljs
+++ b/src/main/frontend/components/paste_source.cljs
@@ -1,8 +1,8 @@
 (ns frontend.components.paste-source
   "Paste raw text — an article, notes, a transcript that isn't already a file —
-  and save it into <graph>/eggs/ as a Markdown source, hatchable like any other.
-  A title + textarea panel; writes eggs/<slug>.md with minimal YAML frontmatter
-  via the :wikiAddEgg IPC (electron.wiki/add-egg!)."
+  and save it into <graph>/pages/ as a Markdown source, hatchable like any other.
+  A title + textarea panel; writes pages/<slug>.md with minimal YAML frontmatter
+  via the :wikiAddSource IPC (electron.wiki/add-source!)."
   (:require [clojure.string :as string]
             [electron.ipc :as ipc]
             [frontend.config :as config]
@@ -24,7 +24,7 @@
       (string/replace #"^-+|-+$" "")
       (as-> s (if (string/blank? s) "pasted-note" (subs s 0 (min 80 (count s)))))))
 
-(defn- egg-content [title body]
+(defn- source-content [title body]
   (str "---\n"
        "title: " (string/replace (string/trim title) #"\n" " ") "\n"
        "added: " (.toISOString (js/Date.)) "\n"
@@ -41,14 +41,14 @@
       :else
       (do
         (reset! *busy? true)
-        (-> (ipc/ipc "wikiAddEgg" (vault-root) (str (slugify title) ".md") (egg-content title body))
+        (-> (ipc/ipc "wikiAddSource" (vault-root) (str (slugify title) ".md") (source-content title body))
             (p/then (fn [r]
                       (let [{:keys [ok name duplicate reason]} (js->clj r :keywordize-keys true)]
                         (cond
                           (and ok duplicate)
                           (notification/show! (str "That text is already in your coop as " duplicate ".") :info true)
                           ok
-                          (do (notification/show! (str "Saved as eggs/" name ".") :success true)
+                          (do (notification/show! (str "Saved as pages/" name ".") :success true)
                               (coop/refresh-counts!)
                               (reset! *title "") (reset! *body "")
                               (when on-saved (on-saved name)))
@@ -78,4 +78,4 @@
       (ui/button {:variant :ghost :size :sm :on-click #(when on-cancel (on-cancel))} "Cancel")
       (ui/button {:size :sm :disabled @*busy?
                   :on-click #(save! *title *body *busy? opts)}
-                 (if @*busy? "Saving…" "Save to eggs/"))]]))
+                 (if @*busy? "Saving…" "Save to pages/"))]]))

--- a/src/main/frontend/components/welcome.cljs
+++ b/src/main/frontend/components/welcome.cljs
@@ -32,7 +32,7 @@
       [:h2#modal-headline.text-xl.mb-1 "Welcome to Kip"]
       [:div.text-xs.opacity-60.mb-2 brand/slogan]]
      [:div.text-sm.opacity-80.space-y-2.my-3
-      [:p "Drop documents into " (glossary/term "eggs/") " and Kip hatches them into "
+       [:p "Drop documents into " (glossary/term "pages/") " and Kip hatches them into "
        (glossary/term "nest/") " — a cross-linked wiki of entity, concept and source pages."]
       [:p "Then " [:b "peck"] " it: ask a question and get an answer that cites the "
        [:code "[[pages]]"] " it came from, or tell Kip a fact to file away."]

--- a/src/main/frontend/components/wiki_status.cljs
+++ b/src/main/frontend/components/wiki_status.cljs
@@ -38,7 +38,7 @@
   (-> (ipc/ipc "wikiIngestPreview" (vault-root))
       (p/then (fn [r] (let [s (bean/->clj r)]
                         ;; total vs changed kept apart (kip-app#113): an
-                        ;; "immutable" egg edited since its hatch is a
+                        ;; "immutable" source edited since its hatch is a
                         ;; different signal from a fresh drop.
                         (reset! *pending {:total (count (:pending s))
                                           :changed (or (:changedCount s) 0)}))))
@@ -139,13 +139,13 @@
 ;; {:total n :changed n} map (or nil) — see fetch-pending!.
 (rum/defc coop-overview < rum/static
   [summary pending]
-  (let [{:keys [eggs entities concepts sources lastHatchAt lastGroomAt]} summary
+  (let [{:keys [sourceFiles entities concepts sources lastHatchAt lastGroomAt]} summary
         nest-total (+ (or entities 0) (or concepts 0) (or sources 0))]
     [:div.mb-4
      [:h3.text-lg.font-medium.mb-1 "Your coop"]
      [:div.text-sm.opacity-80.space-y-0.5
-      [:div (str (or eggs 0) " source " (if (= 1 eggs) "file" "files") " in ")
-       (glossary/term "eggs/")
+      [:div (str (or sourceFiles 0) " source " (if (= 1 sourceFiles) "file" "files") " in ")
+       (glossary/term "pages/")
        (when (and pending (pos? (:total pending 0)))
          [:span " · "
           [:a.underline {:on-click #(state/pub-event! [:modal/show-hatch])}

--- a/src/main/frontend/handler/coop.cljs
+++ b/src/main/frontend/handler/coop.cljs
@@ -1,6 +1,6 @@
 (ns frontend.handler.coop
   "Small reads of the open coop for the first-run checklist — how many source
-  files are in eggs/ and how many pages exist under nest/. Cached in the app
+  files are in pages/ and how many pages exist under nest/. Cached in the app
   db under :kip/coop-counts so the Peck empty state can show what's left to do
   before Kip is useful."
   (:require [cljs-bean.core :as bean]
@@ -13,7 +13,7 @@
   (config/get-repo-dir (state/get-current-repo)))
 
 (defn refresh-counts!
-  "Re-read eggs/ and nest/ counts into :kip/coop-counts. Never throws."
+  "Re-read pages/ and nest/ counts into :kip/coop-counts. Never throws."
   []
   (-> (ipc/ipc "wikiCoopCounts" (vault-root))
       (p/then (fn [r]

--- a/src/main/frontend/handler/graph.cljs
+++ b/src/main/frontend/handler/graph.cljs
@@ -83,7 +83,7 @@
 
 (defn build-global-graph
   "Scoped to the nest/ subtree — the LLM-maintained entity/concept/source
-  pages and the [[wikilinks]] between them. journals/, pages/, eggs/ and
+  pages and the [[wikilinks]] between them. journals/, pages/ and
   clucks/ files are all parsed into the DB as pages too, but excluded from
   this view."
   [theme {:keys [journal? orphan-pages? builtin-pages? excluded-pages?]}]

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -123,9 +123,9 @@
      ;; save). :loaded? false until the first read resolves.
      :kip/llm                               {:loaded? false :configured? false}
 
-     ;; Cached eggs/ + nest/ counts for the Peck first-run checklist —
+     ;; Cached pages/ + nest/ counts for the Peck first-run checklist —
      ;; frontend.handler.coop/refresh-counts!.
-     :kip/coop-counts                       {:loaded? false :eggs 0 :nestPages 0}
+     :kip/coop-counts                       {:loaded? false :sourceFiles 0 :nestPages 0}
 
      ;; Result of the polite update check (frontend.handler.update) —
      ;; {:current :latest :url :notes :newer? :dismissed? :checking?}.

--- a/src/resources/dicts/en.edn
+++ b/src/resources/dicts/en.edn
@@ -53,7 +53,7 @@
  :on-boarding/section-btn-title "Choose a folder"
  :on-boarding/section-btn-desc "Open existing directory or Create a new one"
  :on-boarding/section-title "How Kip saves your work"
- :on-boarding/section-desc "Inside the folder you choose, Kip keeps your pages as plain files. When you hatch your first source it also adds the coop — eggs/, nest/, clucks/ and the rest."
+ :on-boarding/section-desc "Inside the folder you choose, Kip keeps your pages as plain files. When you hatch your first source it also adds the coop — nest/, clucks/ and the rest."
  :on-boarding/section-tip-1 "Each page is a file stored only on your {1}."
  :on-boarding/section-tip-2 "You may choose to sync it later."
  :on-boarding/section-assets "Graphics & Documents"


### PR DESCRIPTION
Pairs with kip#52 (the scripts side of the unified-source-folder change). P2 (nest page-name collision) is deferred.

## What
- The source folder is now `pages/` — Logseq's native notes dir, also the drop-box for Office/PDF and pasted/web-saved sources.
- `electron.wiki`: `add-egg!`/`pick-and-add-eggs!`/`egg-extensions` → `add-source!`/`pick-and-add-sources!`/`source-extensions`; every write/read path points at `pages/`.
- Coop counts now report `:sourceFiles` (the old `:eggs` collided with the nest's `:sources` page count).
- IPC channels `:wikiAddEgg`/`:wikiPickEggs` → `:wikiAddSource`/`:wikiPickSources` (and their renderer call sites).
- Glossary/onboarding/welcome/ingest/paste/drop/chat text: `eggs/` → `pages/`.
- The egg **mark** (`kip_brand/egg-ascii`) is the Kip logo and is intentionally left as-is.

## Note
Not compiled locally (no shadow-cljs `node_modules` here) — this is a mechanical rename across 16 files; please run the build/CI before merge.