### PR TITLE
Tasks panel: todos + due dates + carry-over + reminders (#104 + #108)

### DIFF
--- a/src/electron/electron/handler.cljs
+++ b/src/electron/electron/handler.cljs
@@ -639,6 +639,9 @@
 (defmethod handle :wikiRemindersAdd [_ [_ vault-root text]]
   (wiki/reminders-add! vault-root text))
 
+(defmethod handle :wikiRemindersAddTodo [_ [_ vault-root opts]]
+  (wiki/reminders-add-todo! vault-root opts))
+
 (defmethod handle :wikiRemindersCancel [_ [_ vault-root id]]
   (wiki/reminders-cancel! vault-root id))
 

--- a/src/electron/electron/wiki.cljs
+++ b/src/electron/electron/wiki.cljs
@@ -532,6 +532,18 @@
 (defn reminders-add! [vault-root text]
   (run-node-script! (script "reminders.js") vault-root ["add" text "--json"]))
 
+(defn reminders-add-todo!
+  "Create a reminder for a due-dated todo (frontend.components.todos). Unlike
+  reminders-add!, the todo already has a structured title + due date, so pass
+  them explicitly instead of round-tripping through the natural-language
+  parser. source \"todo\" and lead 0 (fire at the due time) let the todos panel
+  cancel it by id when the todo is checked off."
+  [vault-root {:keys [title event-at]}]
+  (run-node-script! (script "reminders.js") vault-root
+                    (cond-> ["add" "--json" "--source" "todo" "--lead" "0"]
+                      (some? title)    (conj "--title" title)
+                      (some? event-at) (conj "--event-at" event-at))))
+
 (defn reminders-cancel! [vault-root id]
   (run-node-script! (script "reminders.js") vault-root ["cancel" (str id) "--json"]))
 

--- a/src/main/frontend/components/header.cljs
+++ b/src/main/frontend/components/header.cljs
@@ -103,6 +103,11 @@
           :options {:on-click #(state/sidebar-add-block! current-repo "reminders" :reminders)}
           :icon (ui/icon "bell")})
 
+       (when current-repo
+         {:title "Todos"
+          :options {:on-click #(state/sidebar-add-block! current-repo "todos" :todos)}
+          :icon (ui/icon "list-checks")})
+
        (when-not config/publishing?
          {:title [:div.flex-row.flex.justify-between.items-center
                   [:span "Discussions"]]

--- a/src/main/frontend/components/header.cljs
+++ b/src/main/frontend/components/header.cljs
@@ -106,7 +106,7 @@
        (when current-repo
          {:title "Todos"
           :options {:on-click #(state/sidebar-add-block! current-repo "todos" :todos)}
-          :icon (ui/icon "list-checks")})
+          :icon (ui/icon "list-check")})
 
        (when-not config/publishing?
          {:title [:div.flex-row.flex.justify-between.items-center

--- a/src/main/frontend/components/right_sidebar.cljs
+++ b/src/main/frontend/components/right_sidebar.cljs
@@ -5,6 +5,7 @@
             [frontend.components.chat :as chat]
             [frontend.components.exports :as exports]
             [frontend.components.reminders :as reminders]
+            [frontend.components.todos :as todos]
             [frontend.components.telemetry :as telemetry]
             [frontend.components.onboarding :as onboarding]
             [frontend.components.page :as page]
@@ -200,6 +201,10 @@
     :reminders
     [[:.flex.items-center (ui/icon "bell" {:class "text-md mr-2"}) "Reminders"]
      (reminders/reminders-panel)]
+
+    :todos
+    [[:.flex.items-center (ui/icon "list-checks" {:class "text-md mr-2"}) "Todos"]
+     (todos/todos-panel)]
 
     ["" [:span]]))
 

--- a/src/main/frontend/components/right_sidebar.cljs
+++ b/src/main/frontend/components/right_sidebar.cljs
@@ -203,7 +203,7 @@
      (reminders/reminders-panel)]
 
     :todos
-    [[:.flex.items-center (ui/icon "list-checks" {:class "text-md mr-2"}) "Todos"]
+    [[:.flex.items-center (ui/icon "list-check" {:class "text-md mr-2"}) "Todos"]
      (todos/todos-panel)]
 
     ["" [:span]]))

--- a/src/main/frontend/components/todos.cljs
+++ b/src/main/frontend/components/todos.cljs
@@ -1,12 +1,25 @@
 (ns frontend.components.todos
-  "The Todos panel (right-sidebar entry, see :todos in
+  "The Tasks panel (right-sidebar entry, see :todos in
    frontend.components.right-sidebar). A view over the graph's open task
    blocks (TODO / DOING / NOW / LATER markers) with quick capture into today's
    journal. Todos are plain Logseq blocks — no separate store; checking off
    here flips the block's marker to DONE, durable and queryable like any other
-   block."
-  (:require [clojure.string :as string]
+   block.
+
+   The panel is the forward-looking day plan: sections for what's due,
+   today's captures, unfinished items carried over from earlier days, and the
+   rest of the backlog. The journal itself is the backward-looking record — a
+   captured todo stays on its journal day as TODO, then DONE once checked off.
+
+   A captured todo with a due date also projects into the reminder engine
+   (electron-only): a reminder is created at 09:00 on the due date and its id
+   is stored on the block as a :reminder property, so checking the todo off
+   cancels the reminder."
+  (:require [cljs-bean.core :as bean]
+            [clojure.string :as string]
+            [electron.ipc :as ipc]
             [frontend.components.block :as block]
+            [frontend.config :as config]
             [frontend.date :as date]
             [frontend.db :as db]
             [frontend.db-mixins :as db-mixins]
@@ -15,7 +28,9 @@
             [frontend.state :as state]
             [frontend.ui :as ui]
             [frontend.util :as util]
+            [logseq.graph-parser.util.db :as db-util]
             [logseq.graph-parser.util.page-ref :as page-ref]
+            [promesa.core :as p]
             [rum.core :as rum]))
 
 (def ^:private open-markers #{"TODO" "DOING" "NOW" "LATER"})
@@ -28,6 +43,19 @@
 
 (defn- strip-marker [content]
   (string/replace (or content "") marker-prefix-re ""))
+
+;; Block properties are stored as trailing `key:: value` lines; strip them so
+;; the panel renders just the todo text.
+(defn- strip-property-lines [content]
+  (->> (string/split-lines (or content ""))
+       (remove #(re-find #"^\s*[\w-]+::\s" %))
+       (string/join "\n")))
+
+(defn- text-of [block]
+  (-> (:block/content block)
+      strip-marker
+      strip-property-lines
+      string/trim))
 
 ;; --- intelligent linking ----------------------------------------------------
 ;; On capture, wrap the most specific existing page name that appears in the
@@ -69,36 +97,104 @@
             text
             candidates)))
 
+;; --- dates ------------------------------------------------------------------
+;; due dates are stored as `due:: YYYY-MM-DD` block properties and compared as
+;; yyyyMMdd integers against the journal-day of the todo's page.
+
+(defn- due->int [s]
+  (when (string? s)
+    (when-let [[_ y m d] (re-matches #"(\d{4})-(\d{2})-(\d{2})" (string/trim s))]
+      (+ (* (js/parseInt y 10) 10000)
+         (* (js/parseInt m 10) 100)
+         (js/parseInt d 10)))))
+
+(defn- due->iso [s]
+  (when-let [[_ y m d] (re-matches #"(\d{4})-(\d{2})-(\d{2})" (or s ""))]
+    (.toISOString
+     (js/Date. (js/parseInt y 10) (dec (js/parseInt m 10)) (js/parseInt d 10) 9 0 0))))
+
+(defn- vault-root []
+  (config/get-repo-dir (state/get-current-repo)))
+
+;; --- reminder projection ----------------------------------------------------
+
+(defn- add-reminder! [text due-date cb]
+  (let [iso (due->iso due-date)]
+    (if-not iso
+      (cb nil)
+      (-> (ipc/ipc "wikiRemindersAddTodo" (vault-root) {:title text :event-at iso})
+          (p/then (fn [r] (cb (get-in (bean/->clj r) [:reminder :id]))))
+          (p/catch (fn [_] (cb nil)))))))
+
+(defn- cancel-reminder! [id]
+  (-> (ipc/ipc "wikiRemindersCancel" (vault-root) (str id))
+      (p/catch (fn [_] nil))))
+
 ;; --- actions ----------------------------------------------------------------
 
-(defn- add! [*input]
-  (let [text (string/trim @*input)]
+(defn- insert-todo! [linked due-date reminder-id]
+  (editor-handler/api-insert-new-block!
+   (str "TODO " linked)
+   {:page (date/journal-name)
+    :edit-block? false
+    :properties (cond-> {}
+                  (some? due-date) (assoc :due due-date)
+                  (some? reminder-id) (assoc :reminder (str reminder-id)))}))
+
+(defn- add! [*input *due]
+  (let [text (string/trim @*input)
+        due-date (some-> @*due string/trim not-empty)]
     (when-not (string/blank? text)
       (reset! *input "")
+      (reset! *due "")
       (let [repo (state/get-current-repo)
             linked (auto-link-text repo text)]
-        (editor-handler/api-insert-new-block!
-         (str "TODO " linked)
-         {:page (date/journal-name)
-          :edit-block? false})))))
+        (if (and (util/electron?) due-date)
+          (add-reminder! text due-date #(insert-todo! linked due-date %))
+          (insert-todo! linked due-date nil))))))
 
 (defn- check! [block]
-  (editor-handler/set-marker block "DONE"))
+  (editor-handler/set-marker block "DONE")
+  (when-let [reminder-id (get-in block [:block/properties :reminder])]
+    (when (util/electron?)
+      (cancel-reminder! reminder-id))))
 
 ;; --- rendering --------------------------------------------------------------
+
+(defn- bucket [today-int b]
+  (let [d (due->int (get-in b [:block/properties :due]))
+        jd (get-in b [:block/page :block/journal-day])]
+    (cond
+      (and d (<= d today-int)) :due
+      (and d (> d today-int)) :upcoming
+      (and jd (< jd today-int)) :carried
+      (and jd (= jd today-int)) :today
+      :else :backlog)))
+
+(def ^:private section-order
+  [[:due "Due"]
+   [:today "Today"]
+   [:carried "Carried over"]
+   [:upcoming "Upcoming"]
+   [:backlog "Backlog"]])
 
 (rum/defc todo-row < rum/static
   [block]
   (let [page-name (or (get-in block [:block/page :block/original-name])
                       (get-in block [:block/page :block/name])
                       "")
-        text (strip-marker (:block/content block))]
+        text (text-of block)
+        due (get-in block [:block/properties :due])
+        reminder? (contains? (:block/properties block) :reminder)]
     [:div.py-1.px-1.rounded.group.flex.items-start.gap-2
      {:class "hover:bg-gray-03"}
      [:div.flex-1.min-w-0
       [:div.text-sm.leading-snug
        (block/inline-text {} :markdown text)]
-      [:div.text-xs.opacity-40.truncate.pt-0.5 page-name]]
+      [:div.text-xs.opacity-40.truncate.pt-0.5
+       page-name
+       (when due [:span (str " · due " due)])
+       (when reminder? [:span.inline-flex.align-middle.ml-1 (ui/icon "bell" {:size 11 :class "opacity-40"})])]]
      (ui/button {:icon "check" :icon-props {:size 14} :variant :ghost :size :xs
                  :class "opacity-0 group-hover:opacity-100 shrink-0"
                  :title "Done"
@@ -106,25 +202,38 @@
 
 (rum/defcs todos-panel < rum/reactive db-mixins/query
   (rum/local "" ::input)
+  (rum/local "" ::due)
   [state]
   (let [*input (::input state)
+        *due (::due state)
         repo (state/sub :git/current-repo)
+        today-int (db-util/date->int (js/Date.))
         todos (when repo
-                (util/react
-                 (db/q repo [:custom :todos] {:use-cache? false}
-                       '[:find [(pull ?b [:db/id :block/uuid :block/content :block/marker :block/format
-                                          :block/properties :block/repeated?
-                                          {:block/page [:db/id :block/name :block/original-name :block/journal-day]}]) ...]
-                         :where
-                         (or
-                          [?b :block/marker "TODO"]
-                          [?b :block/marker "DOING"]
-                          [?b :block/marker "NOW"]
-                          [?b :block/marker "LATER"])])))
-        todos (->> todos
+                (some-> (db/q repo [:custom :todos] {:use-cache? false}
+                              '[:find [(pull ?b [:db/id :block/uuid :block/content :block/marker :block/format
+                                                :block/properties :block/repeated?
+                                                {:block/page [:db/id :block/name :block/original-name :block/journal-day]}]) ...]
+                                :where
+                                (or
+                                 [?b :block/marker "TODO"]
+                                 [?b :block/marker "DOING"]
+                                 [?b :block/marker "NOW"]
+                                 [?b :block/marker "LATER"])])
+                        util/react))
+        done-today (when repo
+                     (some-> (db/q repo [:custom :todos-done-today] {:use-cache? false}
+                                   '[:find (count ?b) .
+                                     :in $ ?today
+                                     :where
+                                     [?b :block/marker "DONE"]
+                                     [?b :block/page ?p]
+                                     [?p :block/journal-day ?today]]
+                                   today-int)
+                             util/react))
+        todos (->> (or todos [])
                    (sort-by (fn [b] [(get-in b [:block/page :block/original-name] "")
-                                     (get-in b [:block/page :block/name] "")
-                                     (or (:block/content b) "")])))]
+                                     (or (:block/content b) "")])))
+        groups (group-by #(bucket today-int %) todos)]
     [:div.flex.flex-col {:style {:height "100%"}}
      [:div.flex.gap-2.px-1.pb-2
       [:input.form-input.is-small.flex-1.text-sm
@@ -132,13 +241,32 @@
         :placeholder "Add a todo — mention a page to link it"
         :value @*input
         :on-change #(reset! *input (.. % -target -value))
-        :on-key-down (fn [e] (when (= "Enter" (.-key e)) (add! *input)))}]
-      (ui/button {:size :xs :on-click #(add! *input)} "Add")]
+        :on-key-down (fn [e] (when (= "Enter" (.-key e)) (add! *input *due)))}]
+      [:input.form-input.is-small.text-sm
+       {:type "date"
+        :style {:max-width "9em"}
+        :value @*due
+        :on-change #(reset! *due (.. % -target -value))}]
+      (ui/button {:size :xs :on-click #(add! *input *due)} "Add")]
      [:div.flex-1.overflow-y-auto {:class "overflow-x-hidden"}
       (if (empty? todos)
         [:div.text-sm.opacity-50.px-2.py-6.leading-relaxed
          "No open todos. Add one — it lands in today's journal as a "
-         [:code "TODO"] " block, and lives in your graph as a plain file."]
-        [:div.space-y-0.5
-         (for [b todos]
-           (rum/with-key (todo-row b) (str (:block/uuid b))))])]]))
+         [:code "TODO"] " block. Give it a due date to get a reminder."]
+        [:div
+         [:div.text-xs.opacity-50.px-1.pb-1
+          (str (or done-today 0) " done · " (count todos) " open"
+               (when (seq (:carried groups))
+                 (str " · " (count (:carried groups)) " carried")))]
+         (for [[k label] section-order
+               :let [items (if (= k :due)
+                             (sort-by #(due->int (get-in % [:block/properties :due])) (get groups k))
+                             (get groups k))]
+               :when (seq items)]
+           [:div {:key (name k)}
+            [:div.text-xs.uppercase.tracking-wide.opacity-40.px-1.pt-1.pb-1
+             (str label " (" (count items) ")")]
+            [:div.space-y-0.5
+             (for [b items]
+               (rum/with-key (todo-row b) (str (:block/uuid b))))]])])]]))
+

--- a/src/main/frontend/components/todos.cljs
+++ b/src/main/frontend/components/todos.cljs
@@ -25,6 +25,7 @@
             [frontend.db-mixins :as db-mixins]
             [frontend.db.model :as db-model]
             [frontend.handler.editor :as editor-handler]
+            [frontend.handler.editor.property :as editor-property]
             [frontend.state :as state]
             [frontend.ui :as ui]
             [frontend.util :as util]
@@ -113,6 +114,13 @@
     (.toISOString
      (js/Date. (js/parseInt y 10) (dec (js/parseInt m 10)) (js/parseInt d 10) 9 0 0))))
 
+(defn- pad2 [n]
+  (if (< n 10) (str "0" n) (str n)))
+
+(defn- today-str []
+  (let [{:keys [year month day]} (date/get-local-date)]
+    (str year "-" (pad2 month) "-" (pad2 day))))
+
 (defn- vault-root []
   (config/get-repo-dir (state/get-current-repo)))
 
@@ -159,14 +167,22 @@
     (when (util/electron?)
       (cancel-reminder! reminder-id))))
 
+;; The day-end acknowledgment: stamp each carried-over item `carried:: <today>`
+;; so it re-buckets to Today. The block stays on its original journal day (the
+;; record), but now shows it was consciously carried forward.
+(defn- carry-over! [items]
+  (editor-property/batch-add-block-property! (mapv :block/uuid items) :carried (today-str)))
+
 ;; --- rendering --------------------------------------------------------------
 
 (defn- bucket [today-int b]
-  (let [d (due->int (get-in b [:block/properties :due]))
+  (let [due (due->int (get-in b [:block/properties :due]))
+        carried (due->int (get-in b [:block/properties :carried]))
         jd (get-in b [:block/page :block/journal-day])]
     (cond
-      (and d (<= d today-int)) :due
-      (and d (> d today-int)) :upcoming
+      (and due (<= due today-int)) :due
+      (and due (> due today-int)) :upcoming
+      (and carried (= carried today-int)) :today
       (and jd (< jd today-int)) :carried
       (and jd (= jd today-int)) :today
       :else :backlog)))
@@ -185,6 +201,7 @@
                       "")
         text (text-of block)
         due (get-in block [:block/properties :due])
+        carried? (contains? (:block/properties block) :carried)
         reminder? (contains? (:block/properties block) :reminder)]
     [:div.py-1.px-1.rounded.group.flex.items-start.gap-2
      {:class "hover:bg-gray-03"}
@@ -193,6 +210,7 @@
        (block/inline-text {} :markdown text)]
       [:div.text-xs.opacity-40.truncate.pt-0.5
        page-name
+       (when carried? [:span " · carried"])
        (when due [:span (str " · due " due)])
        (when reminder? [:span.inline-flex.align-middle.ml-1 (ui/icon "bell" {:size 11 :class "opacity-40"})])]]
      (ui/button {:icon "check" :icon-props {:size 14} :variant :ghost :size :xs
@@ -203,9 +221,11 @@
 (rum/defcs todos-panel < rum/reactive db-mixins/query
   (rum/local "" ::input)
   (rum/local "" ::due)
+  (rum/local nil ::flash)
   [state]
   (let [*input (::input state)
         *due (::due state)
+        *flash (::flash state)
         repo (state/sub :git/current-repo)
         today-int (db-util/date->int (js/Date.))
         todos (when repo
@@ -258,14 +278,22 @@
           (str (or done-today 0) " done · " (count todos) " open"
                (when (seq (:carried groups))
                  (str " · " (count (:carried groups)) " carried")))]
+         (when @*flash
+           [:div.text-xs.opacity-70.px-1.pb-1 @*flash])
          (for [[k label] section-order
                :let [items (if (= k :due)
                              (sort-by #(due->int (get-in % [:block/properties :due])) (get groups k))
                              (get groups k))]
                :when (seq items)]
            [:div {:key (name k)}
-            [:div.text-xs.uppercase.tracking-wide.opacity-40.px-1.pt-1.pb-1
-             (str label " (" (count items) ")")]
+            [:div.flex.items-center.justify-between.px-1.pt-1.pb-1
+             [:div.text-xs.uppercase.tracking-wide.opacity-40 (str label " (" (count items) ")")]
+             (when (= k :carried)
+               (ui/button {:size :xs
+                           :on-click #(do (carry-over! items)
+                                          (reset! *flash (str "Carried " (count items) " over to today"))
+                                          (js/setTimeout (fn [] (reset! *flash nil)) 2500))}
+                          "Carry over →"))]
             [:div.space-y-0.5
              (for [b items]
                (rum/with-key (todo-row b) (str (:block/uuid b))))]])])]]))

--- a/src/main/frontend/components/todos.cljs
+++ b/src/main/frontend/components/todos.cljs
@@ -1,0 +1,144 @@
+(ns frontend.components.todos
+  "The Todos panel (right-sidebar entry, see :todos in
+   frontend.components.right-sidebar). A view over the graph's open task
+   blocks (TODO / DOING / NOW / LATER markers) with quick capture into today's
+   journal. Todos are plain Logseq blocks — no separate store; checking off
+   here flips the block's marker to DONE, durable and queryable like any other
+   block."
+  (:require [clojure.string :as string]
+            [frontend.components.block :as block]
+            [frontend.date :as date]
+            [frontend.db :as db]
+            [frontend.db-mixins :as db-mixins]
+            [frontend.db.model :as db-model]
+            [frontend.handler.editor :as editor-handler]
+            [frontend.state :as state]
+            [frontend.ui :as ui]
+            [frontend.util :as util]
+            [logseq.graph-parser.util.page-ref :as page-ref]
+            [rum.core :as rum]))
+
+(def ^:private open-markers #{"TODO" "DOING" "NOW" "LATER"})
+
+(def ^:private marker-prefix-re
+  #"^(NOW|LATER|TODO|DOING|DONE|WAITING|WAIT|CANCELED|CANCELLED|IN-PROGRESS)\s+")
+
+(def ^:private marker-pages
+  #{"TODO" "DONE" "DOING" "NOW" "LATER" "WAITING" "WAIT" "CANCELED" "CANCELLED" "IN-PROGRESS"})
+
+(defn- strip-marker [content]
+  (string/replace (or content "") marker-prefix-re ""))
+
+;; --- intelligent linking ----------------------------------------------------
+;; On capture, wrap the most specific existing page name that appears in the
+;; text (whole-word, case-insensitive) in [[...]]. v1 links a single page and
+;; stops; multi-link is a follow-up.
+
+(defn- alnum? [ch]
+  (boolean (re-find #"[A-Za-z0-9]" (str ch))))
+
+(defn- boundary-match-index [text needle]
+  (let [lt (string/lower-case text)
+        ln (string/lower-case needle)
+        len (count needle)]
+    (loop [i 0]
+      (let [idx (string/index-of lt ln i)]
+        (when idx
+          (let [before-ok (or (zero? idx) (not (alnum? (subs text (dec idx) idx))))
+                after-ok (or (>= (+ idx len) (count text))
+                             (not (alnum? (subs text (+ idx len) (+ idx len 1)))))]
+            (if (and before-ok after-ok)
+              idx
+              (recur (inc idx)))))))))
+
+(defn- auto-link-text [repo text]
+  (let [candidates (->> (db-model/get-pages repo)
+                        (map str)
+                        (remove #(contains? marker-pages (string/upper-case %)))
+                        (filter #(>= (count %) 4))
+                        (sort-by (comp - count))
+                        (take 400))]
+    (reduce (fn [s page-name]
+              (if (string/includes? s "[[")
+                s
+                (if-let [idx (boundary-match-index s page-name)]
+                  (str (subs s 0 idx)
+                       (page-ref/->page-ref page-name)
+                       (subs s (+ idx (count page-name))))
+                  s)))
+            text
+            candidates)))
+
+;; --- actions ----------------------------------------------------------------
+
+(defn- add! [*input]
+  (let [text (string/trim @*input)]
+    (when-not (string/blank? text)
+      (reset! *input "")
+      (let [repo (state/get-current-repo)
+            linked (auto-link-text repo text)]
+        (editor-handler/api-insert-new-block!
+         (str "TODO " linked)
+         {:page (date/journal-name)
+          :edit-block? false})))))
+
+(defn- check! [block]
+  (editor-handler/set-marker block "DONE"))
+
+;; --- rendering --------------------------------------------------------------
+
+(rum/defc todo-row < rum/static
+  [block]
+  (let [page-name (or (get-in block [:block/page :block/original-name])
+                      (get-in block [:block/page :block/name])
+                      "")
+        text (strip-marker (:block/content block))]
+    [:div.py-1.px-1.rounded.group.flex.items-start.gap-2
+     {:class "hover:bg-gray-03"}
+     [:div.flex-1.min-w-0
+      [:div.text-sm.leading-snug
+       (block/inline-text {} :markdown text)]
+      [:div.text-xs.opacity-40.truncate.pt-0.5 page-name]]
+     (ui/button {:icon "check" :icon-props {:size 14} :variant :ghost :size :xs
+                 :class "opacity-0 group-hover:opacity-100 shrink-0"
+                 :title "Done"
+                 :on-click #(check! block)})]))
+
+(rum/defcs todos-panel < rum/reactive db-mixins/query
+  (rum/local "" ::input)
+  [state]
+  (let [*input (::input state)
+        repo (state/sub :git/current-repo)
+        todos (when repo
+                (util/react
+                 (db/q repo [:custom :todos] {:use-cache? false}
+                       '[:find [(pull ?b [:db/id :block/uuid :block/content :block/marker :block/format
+                                          :block/properties :block/repeated?
+                                          {:block/page [:db/id :block/name :block/original-name :block/journal-day]}]) ...]
+                         :where
+                         (or
+                          [?b :block/marker "TODO"]
+                          [?b :block/marker "DOING"]
+                          [?b :block/marker "NOW"]
+                          [?b :block/marker "LATER"])])))
+        todos (->> todos
+                   (sort-by (fn [b] [(get-in b [:block/page :block/original-name] "")
+                                     (get-in b [:block/page :block/name] "")
+                                     (or (:block/content b) "")])))]
+    [:div.flex.flex-col {:style {:height "100%"}}
+     [:div.flex.gap-2.px-1.pb-2
+      [:input.form-input.is-small.flex-1.text-sm
+       {:type "text"
+        :placeholder "Add a todo — mention a page to link it"
+        :value @*input
+        :on-change #(reset! *input (.. % -target -value))
+        :on-key-down (fn [e] (when (= "Enter" (.-key e)) (add! *input)))}]
+      (ui/button {:size :xs :on-click #(add! *input)} "Add")]
+     [:div.flex-1.overflow-y-auto {:class "overflow-x-hidden"}
+      (if (empty? todos)
+        [:div.text-sm.opacity-50.px-2.py-6.leading-relaxed
+         "No open todos. Add one — it lands in today's journal as a "
+         [:code "TODO"] " block, and lives in your graph as a plain file."]
+        [:div.space-y-0.5
+         (for [b todos]
+           (rum/with-key (todo-row b) (str (:block/uuid b))))])]]))


### PR DESCRIPTION
Combines #104 (capture + linking) and #108 (task management) into one brain-native **Tasks** panel.

## What
- **Capture** into today's journal; the most specific mentioned page name is auto-linked (`[[...]]`) — #104.
- **Check-off** flips the marker to DONE in place — the journal becomes a per-day record of planned → done.
- **Due dates** on capture (native date input) → stored as `due::` block property.
- **Sections** (no tabs): Due (today/overdue), Today, Carried over, Upcoming, Backlog. Carry-over is *virtual* — open items from earlier journal days are grouped, never moved, so the journal stays honest.
- **Summary header**: "N done · M open · K carried".
- **Reminder projection** (electron only): a due-dated todo creates a reminder at 09:00 on the due date and stores its id as a `:reminder` property; checking it off cancels the reminder. Depends on [kip#53](https://github.com/JWE24-code/kip/pull/53).

## Design decisions
- Data is 100% graph-native markdown: todos are `TODO` blocks; due/reminder are block properties; no separate store.
- Carry-over needs no scheduler — it's derived from `open AND journal-day < today`.
- Reminders stay the alarm clock (`reminders.json` + existing scheduler); the graph stays the source of truth.

## Not compiled locally
No shadow-cljs here; verified paren-balance + JS tests (kip#53: 21/21). Please run the build/CI before merge.