### PR TITLE
fix: People panel always empty (node path.name is undefined)

### DIFF
--- a/src/electron/electron/wiki.cljs
+++ b/src/electron/electron/wiki.cljs
@@ -530,7 +530,7 @@
                   (->> (fs/readdirSync dir)
                        (filter md-file?)
                        (map (fn [f]
-                              (let [slug (.name node-path f)
+                              (let [slug (.basename node-path f ".md")
                                     raw (fs/readFileSync (.join node-path dir f) "utf8")
                                     fm (parse-frontmatter raw)]
                                 {:slug slug


### PR DESCRIPTION
## Problem

The People/Addressbook panel showed "No people yet" even when `nest/people/*.md` person pages existed on disk.

## Root cause

`people-list!` in `src/electron/electron/wiki.cljs` computed the slug with `(.name node-path f)`. But `electron.wiki` requires plain Node `["path" :as node-path]`, and Node's `path` module has **no `.name` method** — only `path.parse(f).name` exists. (The `.name` helper is defined on the *renderer-side* `frontend.utils/nodePath` wrapper, a different object.)

So `node_path.name(f)` threw `TypeError: node_path.name is not a function` on the first file, the surrounding `(catch :default _ [])` swallowed it, and `people-list!` always resolved `{:people []}`.

Because `slug` is the first binding in the `let`, this throw happens *before* `parse-frontmatter` is ever reached — which is why the `b5c631aef` "People panel empty" fix (to `parse-frontmatter`) didn't resolve it.

## Fix

Use `(.basename node-path f ".md")` — the two-arg `path.basename` strips the suffix, producing the same slug shape (`nest/people/<slug>.md` → `<slug>`) that `resolvePage` and `people-merge!` already expect. Consistent with the other `node-path` calls in this file.

Verified: `path.basename('jane-doe.md', '.md')` → `'jane-doe'`; `typeof path.name` → `'undefined'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)