### PR TITLE
release: v0.5.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to the Kip desktop app. The retrieval layer has its own
 changelog at [JWE24-code/kip](https://github.com/JWE24-code/kip/blob/main/CHANGELOG.md).
 
+## [0.5.5] — 2026-09-06
+
+- **People panel now lists your people** — `people-list!` called a Node
+  `path.name` that doesn't exist, so the read threw and the panel showed
+  "No people yet" no matter how many person pages were in the nest. (The
+  0.5.4 frontmatter-parser fix was necessary but not sufficient.)
+- **Delete a person from the People panel** — each row gets a delete action
+  behind a confirm; it removes the `nest/people/<slug>.md` page and its
+  index entry, and regenerates the nest catalog. `[[links]]` to the person
+  elsewhere are left in place.
+- **Follow-up name autocomplete** — toggle "Follow-up" in the Tasks panel and
+  start typing a name: a dropdown suggests people already in your coop
+  (matched on name + aliases, prefix hits first), with arrow-key / click
+  selection.
+
 ## [0.5.4] — 2026-09-05
 
 - **Fix: blank buttons in the Reminders / LLM / Skills panels** — the shared

--- a/resources/package.json
+++ b/resources/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kip",
   "productName": "Kip",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "main": "electron.js",
   "author": "Joeri Weitmann",
   "license": "AGPL-3.0",

--- a/src/main/frontend/version.cljs
+++ b/src/main/frontend/version.cljs
@@ -1,3 +1,3 @@
 (ns ^:no-doc frontend.version)
 
-(defonce version "0.5.4")
+(defonce version "0.5.5")


### PR DESCRIPTION
Version bump + changelog for **v0.5.5**. Tag `v0.5.5` pushed after merge → CI builds both platforms and publishes the GitHub Release.

Contents (all already merged to `version/file`):
- People panel now lists people — `path.name` fix (#134)
- Delete a person from the People panel (#135, kip #65)
- Follow-up name autocomplete in the Tasks panel (#136)

Files: `version.cljs`, `resources/package.json`, `CHANGELOG.md` — same shape as the v0.5.4 release commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)